### PR TITLE
[FIX] #9 UIColor HexCode 범위 초과 에러

### DIFF
--- a/CPR2U/CPR2U/UIColor+.swift
+++ b/CPR2U/CPR2U/UIColor+.swift
@@ -17,11 +17,11 @@ extension UIColor {
            )
     }
     
-    static let white = UIColor(rgb: 0xFFF6F6)
+    static let mainWhite = UIColor(rgb: 0xFFF6F6)
     
-    static let black = UIColor(rgb: 0x19191B)
-    static let darkGray = UIColor(rgb: 0x595959)
-    static let lightGray = UIColor(rgb: 0xD9D9D9)
+    static let mainBlack = UIColor(rgb: 0x19191B)
+    static let mainDarkGray = UIColor(rgb: 0x595959)
+    static let mainLightGray = UIColor(rgb: 0xD9D9D9)
     
     static let mainDarkRed = UIColor(rgb: 0xB50000)
     static let mainRed = UIColor(rgb: 0xF74346)

--- a/CPR2U/CPR2U/UIColor+.swift
+++ b/CPR2U/CPR2U/UIColor+.swift
@@ -10,9 +10,10 @@ import UIKit
 extension UIColor {
     convenience init(rgb: Int) {
            self.init(
-            red: CGFloat((rgb >> 16) & 0xFF),
-            green: CGFloat((rgb >> 8) & 0xFF),
-            blue: CGFloat(rgb & 0xFF), alpha: 1
+            red: CGFloat((rgb >> 16) & 0xFF) / 255.0,
+            green: CGFloat((rgb >> 8) & 0xFF) / 255.0,
+            blue: CGFloat(rgb & 0xFF) / 255.0,
+            alpha: 1
            )
     }
     


### PR DESCRIPTION
### One line Description
- UIColor convenience init에서 빠진 255 나누기 연산 구문 추가

### Work Detail(Optional)
**기존 코드**
```swift
convenience init(rgb: Int) {
           self.init(
            red: CGFloat((rgb >> 16) & 0xFF),
            green: CGFloat((rgb >> 8) & 0xFF),
            blue: CGFloat(rgb & 0xFF), alpha: 1
           )
    }
```
**바뀐 코드**
```swift
convenience init(rgb: Int) {
           self.init(
            red: CGFloat((rgb >> 16) & 0xFF) / 255.0,
            green: CGFloat((rgb >> 8) & 0xFF) / 255.0,
            blue: CGFloat(rgb & 0xFF) / 255.0,
            alpha: 1
           )
    }
```

+ 추가적으로 기존에 UIColor로 존재하는 색상들의 이름을 아래와 같이 변경했습니다.

|기존에 중복되던 UIColor 이름|바뀐 이름|
|:---:|:---:|
|`white`|`mainWhite`|
|`black`|`mainBlack`|
|`darkGray`|`mainDarkGray`|
|`lightGray`|`mainLightGray`|

### Issue
- #9 
- Close #9 