### PR TITLE
[FEAT] #26 교육 로직 구현 - 메인 파트

### DIFF
--- a/CPR2U/CPR2U.xcodeproj/project.pbxproj
+++ b/CPR2U/CPR2U.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		3A396B8F29C89DA3009B0545 /* EducationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B8E29C89DA3009B0545 /* EducationViewModel.swift */; };
 		3A396B9129C8A87D009B0545 /* ViewModelList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B9029C8A87D009B0545 /* ViewModelList.swift */; };
 		3A396B9329C97E31009B0545 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B9229C97E31009B0545 /* UIView+.swift */; };
-		3A50F39129BF426E00DC1E29 /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A50F39029BF426E00DC1E29 /* Private.plist */; };
 		3A50F39329BF51F800DC1E29 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A50F39229BF51F800DC1E29 /* UIButton+.swift */; };
 		3A5C390E29C0844700378015 /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3A5C390D29C0844700378015 /* CombineCocoa */; };
 		3A5C391029C08C8900378015 /* QuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5C390F29C08C8900378015 /* QuizViewModel.swift */; };
@@ -100,7 +99,6 @@
 		3A396B8E29C89DA3009B0545 /* EducationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationViewModel.swift; sourceTree = "<group>"; };
 		3A396B9029C8A87D009B0545 /* ViewModelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelList.swift; sourceTree = "<group>"; };
 		3A396B9229C97E31009B0545 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
-		3A50F39029BF426E00DC1E29 /* Private.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Private.plist; sourceTree = "<group>"; };
 		3A50F39229BF51F800DC1E29 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		3A5C390F29C08C8900378015 /* QuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
 		3A5C391229C0948F00378015 /* Quiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quiz.swift; sourceTree = "<group>"; };
@@ -350,7 +348,6 @@
 				3AA636B629AE5057006BB5EF /* Assets.xcassets */,
 				3AA636B829AE5057006BB5EF /* LaunchScreen.storyboard */,
 				3AA636BB29AE5057006BB5EF /* Info.plist */,
-				3A50F39029BF426E00DC1E29 /* Private.plist */,
 			);
 			path = CPR2U;
 			sourceTree = "<group>";
@@ -509,7 +506,6 @@
 			files = (
 				3AA636C929B08402006BB5EF /* NotoSans-Regular.ttf in Resources */,
 				3AA636C829B08402006BB5EF /* NotoSans-Bold.ttf in Resources */,
-				3A50F39129BF426E00DC1E29 /* Private.plist in Resources */,
 				3A324CD829C60E6400165E2E /* movenet_thunder.tflite in Resources */,
 				3AA636BA29AE5057006BB5EF /* LaunchScreen.storyboard in Resources */,
 				3AA636B729AE5057006BB5EF /* Assets.xcassets in Resources */,

--- a/CPR2U/CPR2U.xcodeproj/project.pbxproj
+++ b/CPR2U/CPR2U.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		3A324CEC29C611AB00165E2E /* CameraOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A324CEB29C611AB00165E2E /* CameraOverlayView.swift */; };
 		3A396B8F29C89DA3009B0545 /* EducationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B8E29C89DA3009B0545 /* EducationViewModel.swift */; };
 		3A396B9129C8A87D009B0545 /* ViewModelList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B9029C8A87D009B0545 /* ViewModelList.swift */; };
+		3A396B9329C97E31009B0545 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B9229C97E31009B0545 /* UIView+.swift */; };
 		3A50F39129BF426E00DC1E29 /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A50F39029BF426E00DC1E29 /* Private.plist */; };
 		3A50F39329BF51F800DC1E29 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A50F39229BF51F800DC1E29 /* UIButton+.swift */; };
 		3A5C390E29C0844700378015 /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3A5C390D29C0844700378015 /* CombineCocoa */; };
@@ -98,6 +99,7 @@
 		3A324CEB29C611AB00165E2E /* CameraOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraOverlayView.swift; sourceTree = "<group>"; };
 		3A396B8E29C89DA3009B0545 /* EducationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationViewModel.swift; sourceTree = "<group>"; };
 		3A396B9029C8A87D009B0545 /* ViewModelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelList.swift; sourceTree = "<group>"; };
+		3A396B9229C97E31009B0545 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		3A50F39029BF426E00DC1E29 /* Private.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Private.plist; sourceTree = "<group>"; };
 		3A50F39229BF51F800DC1E29 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		3A5C390F29C08C8900378015 /* QuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 				3AA636F429B61D67006BB5EF /* UIViewController+.swift */,
 				3A22BF6629BE05D9004411BE /* Encodable+.swift */,
 				3A50F39229BF51F800DC1E29 /* UIButton+.swift */,
+				3A396B9229C97E31009B0545 /* UIView+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -564,6 +567,7 @@
 				3AA636ED29B5E816006BB5EF /* LoginViewModel.swift in Sources */,
 				3A324CDF29C60E9F00165E2E /* PoseData.swift in Sources */,
 				3ADE726829BB21BE00EEE19C /* CustomNoticeView.swift in Sources */,
+				3A396B9329C97E31009B0545 /* UIView+.swift in Sources */,
 				3ADE727229BB64D400EEE19C /* EvaluationResultView.swift in Sources */,
 				3A324CE729C6104D00165E2E /* Data+TFLite.swift in Sources */,
 				3A324CEC29C611AB00165E2E /* CameraOverlayView.swift in Sources */,

--- a/CPR2U/CPR2U.xcodeproj/project.pbxproj
+++ b/CPR2U/CPR2U.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		3A324CE729C6104D00165E2E /* Data+TFLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A324CE629C6104D00165E2E /* Data+TFLite.swift */; };
 		3A324CEA29C6111200165E2E /* CameraFeedManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A324CE929C6111200165E2E /* CameraFeedManager.swift */; };
 		3A324CEC29C611AB00165E2E /* CameraOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A324CEB29C611AB00165E2E /* CameraOverlayView.swift */; };
+		3A396B8F29C89DA3009B0545 /* EducationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B8E29C89DA3009B0545 /* EducationViewModel.swift */; };
+		3A396B9129C8A87D009B0545 /* ViewModelList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B9029C8A87D009B0545 /* ViewModelList.swift */; };
 		3A50F39129BF426E00DC1E29 /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A50F39029BF426E00DC1E29 /* Private.plist */; };
 		3A50F39329BF51F800DC1E29 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A50F39229BF51F800DC1E29 /* UIButton+.swift */; };
 		3A5C390E29C0844700378015 /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3A5C390D29C0844700378015 /* CombineCocoa */; };
@@ -94,6 +96,8 @@
 		3A324CE629C6104D00165E2E /* Data+TFLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+TFLite.swift"; sourceTree = "<group>"; };
 		3A324CE929C6111200165E2E /* CameraFeedManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraFeedManager.swift; sourceTree = "<group>"; };
 		3A324CEB29C611AB00165E2E /* CameraOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraOverlayView.swift; sourceTree = "<group>"; };
+		3A396B8E29C89DA3009B0545 /* EducationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationViewModel.swift; sourceTree = "<group>"; };
+		3A396B9029C8A87D009B0545 /* ViewModelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelList.swift; sourceTree = "<group>"; };
 		3A50F39029BF426E00DC1E29 /* Private.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Private.plist; sourceTree = "<group>"; };
 		3A50F39229BF51F800DC1E29 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		3A5C390F29C08C8900378015 /* QuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
@@ -180,6 +184,7 @@
 			children = (
 				3A22BF4129BC90E7004411BE /* Constants */,
 				3A22BF3E29BC8C62004411BE /* Extension */,
+				3A396B9029C8A87D009B0545 /* ViewModelList.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -394,6 +399,7 @@
 				3ADE725329B9D69D00EEE19C /* CertificateStatusView.swift */,
 				3ADE725529B9EA3200EEE19C /* EducationProgressView.swift */,
 				3ADE725929BA333D00EEE19C /* EducationCollectionViewCell.swift */,
+				3A396B8E29C89DA3009B0545 /* EducationViewModel.swift */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -548,6 +554,7 @@
 				3ADE725229B9D55100EEE19C /* EducationMainViewController.swift in Sources */,
 				3ADE726229BB047300EEE19C /* QuizChoiceView.swift in Sources */,
 				3AA636F529B61D67006BB5EF /* UIViewController+.swift in Sources */,
+				3A396B8F29C89DA3009B0545 /* EducationViewModel.swift in Sources */,
 				3AA636F329B5F20D006BB5EF /* UITextField+.swift in Sources */,
 				3AA636EB29B5B30D006BB5EF /* TestViewController.swift in Sources */,
 				3A5C391029C08C8900378015 /* QuizViewModel.swift in Sources */,
@@ -586,6 +593,7 @@
 				3A324CE129C60EAC00165E2E /* PoseEstimator.swift in Sources */,
 				3ADE727629BB78BF00EEE19C /* AccuracyResultView.swift in Sources */,
 				3AA636B029AE5055006BB5EF /* SceneDelegate.swift in Sources */,
+				3A396B9129C8A87D009B0545 /* ViewModelList.swift in Sources */,
 				3A22BF5F29BDFF1A004411BE /* NetworkRequest.swift in Sources */,
 				3ADE725A29BA333D00EEE19C /* EducationCollectionViewCell.swift in Sources */,
 				3A324CD229C4BCE000165E2E /* MultiQuizChoiceView.swift in Sources */,

--- a/CPR2U/CPR2U/Application/SceneDelegate.swift
+++ b/CPR2U/CPR2U/Application/SceneDelegate.swift
@@ -17,11 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
         
         self.window = window
-//        let navVC = UINavigationController(rootViewController: EducationMainViewController())
-//        window.rootViewController =  navVC
-        let vc = PosePracticeViewController()
-        window.rootViewController =  vc
+        let navVC = UINavigationController(rootViewController: EducationMainViewController())
+        window.rootViewController =  navVC
         window.backgroundColor = .white
+        window.overrideUserInterfaceStyle = .light
         window.makeKeyAndVisible()
     }
 

--- a/CPR2U/CPR2U/Scene/Education/Main/CertificateStatusView.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/CertificateStatusView.swift
@@ -9,16 +9,27 @@ import UIKit
 
 final class CertificateStatusView: UIView {
 
+    private let status: AngelStatus = .unacquired
     private let certificateImage = UIImageView()
-    private let greetingLabel = UILabel()
-    private let certificateLabel = UILabel()
+    private lazy var  greetingLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(weight: .regular, size: 14)
+        label.textColor = .mainBlack
+        return label
+    }()
+    
+    private lazy var certificateLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(weight: .regular, size: 14)
+        label.textColor = .mainBlack
+        return label
+    }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         setUpConstraints()
         setUpStyle()
-        setUpText()
     }
     
     required init?(coder: NSCoder) {
@@ -85,20 +96,33 @@ final class CertificateStatusView: UIView {
         self.layer.borderColor = UIColor.mainRed.cgColor
         self.layer.borderWidth = 1
         self.backgroundColor = .mainWhite
-        
-        certificateImage.image = UIImage(named: "person.png")
-        
-        greetingLabel.font = UIFont(weight: .regular, size: 14)
-        greetingLabel.textColor = .mainBlack
-        
-        
-        // TODO: 로직 구현 시, certificateLabel NAttributedText 적용 예정
-        certificateLabel.font = UIFont(weight: .bold, size: 16)
-        certificateLabel.textColor = .mainBlack
     }
     
-    private func setUpText() {
-        greetingLabel.text = "Hi HeartBeatingS2,"
-        certificateLabel.text = "You are not a CPR ANGEL yet."
+    func setUpStatus(as status: AngelStatus, leftDay: Int?) {
+        
+        let imgName = status.certificationImageName()
+        certificateImage.image = UIImage(named: imgName)
+        
+        var statusString: String
+        if let leftDayString = leftDay {
+            statusString = "\(status.certificationStatus()) (D-\(leftDayString))"
+        } else {
+            statusString = status.certificationStatus()
+        }
+        let certificateStatusString = "Certificate Status: "
+        let customFont = UIFont(weight: .bold, size: 14)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: customFont,
+            .foregroundColor: UIColor.mainRed
+        ]
+        let resultString = NSMutableAttributedString(string: certificateStatusString)
+        let attributedString = NSMutableAttributedString(string: statusString, attributes: attributes)
+        resultString.append(attributedString)
+        
+        certificateLabel.attributedText = resultString
+    }
+    
+    func setUpGreetingLabel(nickname: String) {
+        greetingLabel.text = "Hi \(nickname)"
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationCollectionViewCell.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationCollectionViewCell.swift
@@ -11,15 +11,29 @@ final class EducationCollectionViewCell: UICollectionViewCell {
     
     static let identifier = "EducationCollectionViewCell"
     
-    let educationNameLabel = UILabel()
-    let descriptionLabel = UILabel()
-    let statusLabel = UILabel()
+    private lazy var educationNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(weight: .bold, size: 16)
+        label.textColor = .mainBlack
+        return label
+    }()
+    private lazy var descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(weight: .regular, size: 12)
+        label.textColor = .mainBlack
+        return label
+    }()
+    private lazy var statusLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(weight: .bold, size: 16)
+        label.textColor = .mainRed
+        return label
+    }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         setUpConstraints()
         setUpStyle()
-        setUpText()
     }
     
     required init?(coder: NSCoder) {
@@ -62,23 +76,21 @@ final class EducationCollectionViewCell: UICollectionViewCell {
     }
     
     private func setUpStyle() {
-        self.backgroundColor = .mainLightRed
         self.layer.cornerRadius = 20
-        
-        educationNameLabel.font = UIFont(weight: .bold, size: 16)
-        descriptionLabel.font = UIFont(weight: .regular, size: 12)
-        statusLabel.font = UIFont(weight: .bold, size: 16)
-        
-        educationNameLabel.textColor = .mainBlack
-        descriptionLabel.textColor = .mainBlack
-        statusLabel.textColor = .mainRed
-        
     }
     
-    private func setUpText() {
-        educationNameLabel.text = "Lecture"
-        descriptionLabel.text = "Video lecture for CPR angel certificate"
-        statusLabel.text = "Completed"
+    func setUpEducationNameLabel(as str: String) {
+        educationNameLabel.text = str
+    }
+    
+    func setUpDescriptionLabel(as str: String) {
+        descriptionLabel.text = str
+    }
+    
+    func setUpStatus(isCompleted: Bool) {
+        statusLabel.text = isCompleted == true ? "Completed" : "Not Completed"
+        statusLabel.textColor = isCompleted == true ? .mainRed : .mainDarkGray
+        self.backgroundColor = isCompleted  == true ? .mainLightRed : .mainLightGray
     }
 
 }

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
@@ -8,11 +8,6 @@
 import Combine
 import UIKit
 
-// MARK: 로직 파트
-// TODO: Education Big Label...
-// MARK: 서버 파트
-// TODO: 암튼 많음
-
 final class EducationMainViewController: UIViewController {
 
     let eduStatus: [String] = ["Completed", "Not Completed", "Not Completed"]

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
@@ -5,17 +5,18 @@
 //  Created by 황정현 on 2023/03/09.
 //
 
+import Combine
 import UIKit
 
 final class EducationMainViewController: UIViewController {
-    
-    let eduName: [String] = ["Lecture" , "Quiz", "Pose Practice"]
-    let eduDescription: [String] = ["Video lecture for CPR angel certificate", "Let’s check your CPR study", "Posture practice to get CPR angel certificate"]
+
     let eduStatus: [String] = ["Completed", "Not Completed", "Not Completed"]
-    private let certificateStatusView = CertificateStatusView()
+    private var certificateStatusView = CertificateStatusView()
     private let progressView = EducationProgressView()
     private let educationCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     
+    private let viewModel = EducationViewModel()
+    private var cancellables = Set<AnyCancellable>()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,6 +24,7 @@ final class EducationMainViewController: UIViewController {
         setUpConstraints()
         setUpStyle()
         setUpCollectionView()
+        bind(to: viewModel)
     }
     
     private func setUpConstraints() {
@@ -60,15 +62,11 @@ final class EducationMainViewController: UIViewController {
     }
     
     private func setUpStyle() {
-        view.backgroundColor = .mainWhite
         guard let navBar = self.navigationController?.navigationBar else { return }
         navBar.prefersLargeTitles = true
         navBar.topItem?.title = "Education"
         navBar.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.mainRed]
         self.navigationController?.navigationItem.largeTitleDisplayMode = .automatic
-        
-        educationCollectionView.backgroundColor = .mainWhite
-        educationCollectionView.contentInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
     }
     
     private func setUpCollectionView() {
@@ -76,19 +74,39 @@ final class EducationMainViewController: UIViewController {
         educationCollectionView.delegate = self
         educationCollectionView.register(EducationCollectionViewCell.self, forCellWithReuseIdentifier: EducationCollectionViewCell.identifier)
     }
+    
+    private func bind(to viewModel: EducationViewModel) {
+        
+        // TEST
+        let input = EducationViewModel.Input(nickname: "HeartBeatingS2", angelStatus: 2, progressPercent: 1.0, leftDay: nil, isLectureCompleted: true, isQuizCompleted: true, isPostureCompleted: true)
+        
+        let output = viewModel.transform(input: input)
+        
+        output.certificateStatus.sink { status in
+            self.certificateStatusView.setUpStatus(as: status.status, leftDay: status.leftDay)
+        }.store(in: &cancellables)
+        
+        output.nickname.sink { nickname in
+            self.certificateStatusView.setUpGreetingLabel(nickname: nickname)
+        }.store(in: &cancellables)
+        
+        output.progressPercent.sink { progress in
+            self.progressView.setUpProgress(as: progress)
+        }.store(in: &cancellables)
+    }
 }
 
 extension EducationMainViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return eduName.count
+        return viewModel.educationName().count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "EducationCollectionViewCell", for: indexPath) as! EducationCollectionViewCell
         
-        cell.educationNameLabel.text = eduName[indexPath.row]
-        cell.descriptionLabel.text = eduDescription[indexPath.row]
-        cell.statusLabel.text = eduStatus[indexPath.row]
+        cell.setUpEducationNameLabel(as: viewModel.educationName()[indexPath.row])
+        cell.setUpDescriptionLabel(as: viewModel.educationDescription()[indexPath.row])
+        cell.setUpStatus(isCompleted: viewModel.educationStatus()[indexPath.row])
         
         return cell
     }

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
@@ -8,6 +8,11 @@
 import Combine
 import UIKit
 
+// MARK: 로직 파트
+// TODO: Education Big Label...
+// MARK: 서버 파트
+// TODO: 암튼 많음
+
 final class EducationMainViewController: UIViewController {
 
     let eduStatus: [String] = ["Completed", "Not Completed", "Not Completed"]

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
@@ -113,7 +113,12 @@ extension EducationMainViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let index = indexPath.row
-        navigateTo(index: index)
+        let isCompleted = index != 0 ? viewModel.educationStatus()[index - 1] : true
+        if isCompleted == true {
+            navigateTo(index: index)
+        } else {
+            view.showToastMessage(type: .education)
+        }
         
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationProgressView.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationProgressView.swift
@@ -9,22 +9,45 @@ import UIKit
 
 final class EducationProgressView: UIView {
 
-    private let annotationLabel = UILabel()
-    private let infoButton = UIButton()
-    private let progressView = UIProgressView()
+    private let annotationLabel: UILabel = {
+        let label = UILabel()
+        let color = UIColor(rgb: 0x767676)
+        label.font = UIFont(weight: .regular, size: 11)
+        label.textColor = color
+        label.text = "CPR Angel Certification Progress"
+        return label
+    }()
+    
+    private let infoButton: UIButton = {
+        let button = UIButton()
+        let color = UIColor(rgb: 0x767676)
+        let config = UIImage.SymbolConfiguration(pointSize: 10, weight: .light, scale: .medium)
+        guard let img = UIImage(systemName: "info.circle", withConfiguration: config)?.withTintColor(color).withRenderingMode(.alwaysOriginal) else { return UIButton() }
+        button.setImage(img, for: .normal)
+        return button
+    }()
+    
+    private lazy var progressView: UIProgressView = {
+        let view = UIProgressView()
+        view.trackTintColor = .mainLightRed.withAlphaComponent(0.05)
+        view.progressTintColor = .mainRed
+        view.layer.borderColor = UIColor.mainRed.cgColor
+        view.layer.borderWidth = 1
+        view.layer.cornerRadius = 8
+        view.layer.sublayers![1].cornerRadius = 8
+        view.clipsToBounds = true
+        return view
+    }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         setUpConstraints()
-        setUpStyle()
-        setUpText()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
     
     private func setUpConstraints() {
         let make = Constraints.shared
@@ -60,24 +83,7 @@ final class EducationProgressView: UIView {
         ])
     }
     
-    private func setUpStyle() {
-        let color = UIColor(rgb: 0x767676)
-        annotationLabel.font = UIFont(weight: .regular, size: 11)
-        annotationLabel.textColor = color
-        let config = UIImage.SymbolConfiguration(pointSize: 10, weight: .light, scale: .medium)
-        guard let img = UIImage(systemName: "info.circle", withConfiguration: config)?.withTintColor(color).withRenderingMode(.alwaysOriginal) else { return }
-        infoButton.setImage(img, for: .normal)
-        progressView.trackTintColor = .mainLightRed.withAlphaComponent(0.05)
-        progressView.progressTintColor = .mainRed
-        progressView.layer.borderColor = UIColor.mainRed.cgColor
-        progressView.layer.borderWidth = 1
-        progressView.layer.cornerRadius = 8
-        progressView.layer.sublayers![1].cornerRadius = 8
-        progressView.clipsToBounds = true
-        progressView.progress = 0.2
-    }
-    
-    private func setUpText() {
-        annotationLabel.text = "CPR Angel Certification Progress"
+    func setUpProgress(as value: Float) {
+        progressView.progress = value
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationViewModel.swift
@@ -82,8 +82,12 @@ final class EducationViewModel: DefaultViewModelType {
         let nickname: CurrentValueSubject<String, Never> = CurrentValueSubject(input.nickname)
         
         let certificateStatus: CurrentValueSubject<CertificateStatus, Never> = {
-            guard let status = AngelStatus(rawValue: input.angelStatus), let leftDayNum = input.leftDay else {
+            guard let status = AngelStatus(rawValue: input.angelStatus) else {
                 return CurrentValueSubject(CertificateStatus(status: AngelStatus.unacquired, leftDay: nil))
+            }
+            
+            guard let leftDayNum = input.leftDay else {
+                return CurrentValueSubject(CertificateStatus(status: status, leftDay: nil))
             }
  
             return CurrentValueSubject(CertificateStatus(status: status, leftDay: leftDayNum))

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationViewModel.swift
@@ -1,0 +1,57 @@
+//
+//  EducationViewModel.swift
+//  CPR2U
+//
+//  Created by 황정현 on 2023/03/20.
+//
+
+import Foundation
+import Combine
+
+enum AngelStatus: Int {
+    case complete
+    case expired
+    case incomplete
+}
+
+enum EducationStatus: Int {
+    case incomplete
+    case lectureComplete
+    case quizComplete
+    case postureComplete
+}
+
+final class EducationViewModel: DefaultViewModelType {
+    struct Input {
+        let angelStatus: Int
+        let progressPercent: Float
+        let isLectureCompleted: Bool
+        let isQuizCompleted: Bool
+        let isPostureCompleted: Bool
+    }
+    
+    struct Output {
+        let angelStatus: CurrentValueSubject<AngelStatus, Never>
+        let progressPercent: CurrentValueSubject<Float, Never>
+        let educationStatus: CurrentValueSubject<EducationStatus, Never>
+    }
+    
+    func transform(input: Input) -> Output {
+        
+        let angelStatus = AngelStatus(rawValue: input.angelStatus)
+        let progressPercent = input.progressPercent
+        let educationStatus: EducationStatus = {
+            if input.isPostureCompleted {
+                return EducationStatus.postureComplete
+            } else if input.isQuizCompleted {
+                return EducationStatus.quizComplete
+            } else if input.isLectureCompleted {
+                return EducationStatus.lectureComplete
+            } else {
+                return EducationStatus.incomplete
+            }
+        }()
+        
+        return Output(angelStatus: CurrentValueSubject(angelStatus ?? .incomplete), progressPercent: CurrentValueSubject(progressPercent), educationStatus: CurrentValueSubject(educationStatus))
+    }
+}

--- a/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
@@ -127,7 +127,7 @@ final class EducationQuizViewController: UIViewController {
     }
     
     private func setUpStyle() {
-        view.backgroundColor = .mainWhite
+        view.backgroundColor = .white
         
         navigationController?.navigationBar.topItem?.title = "Quiz"
         let closeItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(closeButtonTapped))

--- a/CPR2U/CPR2U/Scene/Education/Quiz/QuizViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/QuizViewModel.swift
@@ -8,13 +8,7 @@
 import Foundation
 import Combine
 
-protocol OutputOnlyViewModel {
-    associatedtype Output
-
-    func transform() -> Output
-}
-
-class QuizViewModel: OutputOnlyViewModel {
+class QuizViewModel: OutputOnlyViewModelType {
     private var quizList: [Quiz] = []
     private var currentQuizIndex: Int = 0
     private var didSelectAnswer: Bool = false

--- a/CPR2U/CPR2U/Util/Extension/UIView+.swift
+++ b/CPR2U/CPR2U/Util/Extension/UIView+.swift
@@ -1,0 +1,60 @@
+//
+//  UIView+.swift
+//  CPR2U
+//
+//  Created by 황정현 on 2023/03/21.
+//
+
+import UIKit
+
+enum ToastMessage: Equatable {
+    case login(nickname: String)
+    case education
+    
+    func toastMessage() -> String {
+        switch self {
+        case .login(let nickname):
+            return "‘\(nickname)’ is Available"
+        case .education:
+            return "You must achieve 100% of your previous course progress."
+        }
+    }
+}
+ extension UIView {
+
+     func showToastMessage(type: ToastMessage) {
+         let width = UIScreen.main.bounds.width
+         let height = UIScreen.main.bounds.height
+
+         let toastLabel = UILabel()
+
+         let margin = 8
+
+         let labelYPos = type == .education ? Int(height * 0.84) : Int(height * 0.88)
+         let labelHeight = type == .education ? 80 : 45
+         toastLabel.frame = CGRect(x: margin, y: labelYPos, width: Int(width) - margin * 2, height: labelHeight)
+
+         toastLabel.font = UIFont(weight: .bold, size: 14)
+         toastLabel.text = type.toastMessage()
+         toastLabel.numberOfLines = 2
+         toastLabel.textColor = .mainWhite
+         toastLabel.backgroundColor = .mainBlack
+         toastLabel.textAlignment = .center
+         toastLabel.layer.cornerRadius = 8
+         toastLabel.clipsToBounds = true
+         toastLabel.isUserInteractionEnabled = false
+         toastLabel.layer.opacity = 0
+         self.addSubview(toastLabel)
+
+         UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: {
+             toastLabel.layer.opacity = 1.0
+         }, completion: {_ in
+             UIView.animate(withDuration: 0.5, delay: 0.8, options: .curveEaseOut, animations: {
+                 toastLabel.layer.opacity = 0
+             }, completion: {_ in
+                 toastLabel.removeFromSuperview()
+             })
+         })
+     }
+
+ }

--- a/CPR2U/CPR2U/Util/ViewModelList.swift
+++ b/CPR2U/CPR2U/Util/ViewModelList.swift
@@ -1,0 +1,22 @@
+//
+//  ViewModelList.swift
+//  CPR2U
+//
+//  Created by 황정현 on 2023/03/20.
+//
+
+import Foundation
+
+protocol DefaultViewModelType {
+    associatedtype Input
+    associatedtype Output
+
+    func transform(input: Input) -> Output
+}
+
+
+protocol OutputOnlyViewModelType {
+    associatedtype Output
+
+    func transform() -> Output
+}


### PR DESCRIPTION
### One line Description
교육 탭 메인 화면에서 필요한 로직 구현

### Work Detail(Optional)
**ViewModel 기반으로 데이터 갱신하는 로직 구현**
|ACQUIRED|EXPIRED|UNACQUIRED|
|:---:|:---:|:---:|
|![Simulator Screen Shot - iPhone 14 - 2023-03-21 at 17 18 39](https://user-images.githubusercontent.com/96641477/226552978-9243f4eb-392b-4d6a-9ce3-e71afc1eaa00.png)|![Simulator Screen Shot - iPhone 14 - 2023-03-21 at 17 30 58](https://user-images.githubusercontent.com/96641477/226553225-977bfc79-6da1-4da0-abf8-1c0775465f72.png)|![Simulator Screen Shot - iPhone 14 - 2023-03-21 at 17 16 45](https://user-images.githubusercontent.com/96641477/226552990-d2d91929-366b-4389-8697-32097ed3b593.png)|

|컨텐츠 진입 조건 판별|
|:---:|
|![](https://user-images.githubusercontent.com/96641477/226553690-07b15c3f-6d2e-4039-82a5-9d5514385616.mp4)|

### Issue
- #26
- Close #26