### PR TITLE
[FEAT] #37 교육 로직 구현 - 영상 재생 구현

### DIFF
--- a/CPR2U/CPR2U.xcodeproj/project.pbxproj
+++ b/CPR2U/CPR2U.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		3A396BB929CB2686009B0545 /* Education.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BB829CB2686009B0545 /* Education.swift */; };
 		3A396BBB29CB2C87009B0545 /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BBA29CB2C87009B0545 /* TestViewController.swift */; };
 		3A396BBC29CB2E39009B0545 /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A396BAC29CA138A009B0545 /* Private.plist */; };
+		3A396BC329CCA563009B0545 /* LectureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BC229CCA563009B0545 /* LectureViewController.swift */; };
 		3A50F39329BF51F800DC1E29 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A50F39229BF51F800DC1E29 /* UIButton+.swift */; };
 		3A5C390E29C0844700378015 /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3A5C390D29C0844700378015 /* CombineCocoa */; };
 		3A5C391029C08C8900378015 /* QuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5C390F29C08C8900378015 /* QuizViewModel.swift */; };
@@ -122,6 +123,7 @@
 		3A396BB629CB1F38009B0545 /* EducationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationManager.swift; sourceTree = "<group>"; };
 		3A396BB829CB2686009B0545 /* Education.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Education.swift; sourceTree = "<group>"; };
 		3A396BBA29CB2C87009B0545 /* TestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewController.swift; sourceTree = "<group>"; };
+		3A396BC229CCA563009B0545 /* LectureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureViewController.swift; sourceTree = "<group>"; };
 		3A50F39229BF51F800DC1E29 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		3A5C390F29C08C8900378015 /* QuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
 		3A5C391229C0948F00378015 /* Quiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quiz.swift; sourceTree = "<group>"; };
@@ -387,6 +389,14 @@
 			path = Education;
 			sourceTree = "<group>";
 		};
+		3A396BC129CCA4F1009B0545 /* Lecture */ = {
+			isa = PBXGroup;
+			children = (
+				3A396BC229CCA563009B0545 /* LectureViewController.swift */,
+			);
+			path = Lecture;
+			sourceTree = "<group>";
+		};
 		3A5C391129C0948600378015 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -468,6 +478,7 @@
 			children = (
 				3A396BBA29CB2C87009B0545 /* TestViewController.swift */,
 				3ADE725C29BA3BC000EEE19C /* Main */,
+				3A396BC129CCA4F1009B0545 /* Lecture */,
 				3ADE725D29BA3BCD00EEE19C /* Quiz */,
 				3ADE725E29BA3BDB00EEE19C /* Pose */,
 			);
@@ -639,6 +650,7 @@
 				3A324CDD29C60E9800165E2E /* MoveNet.swift in Sources */,
 				3A396BBB29CB2C87009B0545 /* TestViewController.swift in Sources */,
 				3ADE725229B9D55100EEE19C /* EducationMainViewController.swift in Sources */,
+				3A396BC329CCA563009B0545 /* LectureViewController.swift in Sources */,
 				3A396BB729CB1F38009B0545 /* EducationManager.swift in Sources */,
 				3ADE726229BB047300EEE19C /* QuizChoiceView.swift in Sources */,
 				3AA636F529B61D67006BB5EF /* UIViewController+.swift in Sources */,

--- a/CPR2U/CPR2U/Scene/Education/Lecture/LectureViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Lecture/LectureViewController.swift
@@ -31,6 +31,10 @@ final class LectureViewController: UIViewController {
         loadWebPage()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(true)
+        navigationController?.navigationBar.prefersLargeTitles = false
+    }
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(true)
         navigationController?.navigationBar.prefersLargeTitles = true
@@ -61,7 +65,6 @@ final class LectureViewController: UIViewController {
             guard let stringToURL = URL(string: "http://naver.com") else { return }
             let URLToRequest = URLRequest(url: stringToURL)
             webView.load(URLToRequest)
-            navigationController?.navigationBar.prefersLargeTitles = false
         }
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Lecture/LectureViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Lecture/LectureViewController.swift
@@ -1,0 +1,67 @@
+//
+//  LectureViewController.swift
+//  CPR2U
+//
+//  Created by 황정현 on 2023/03/24.
+//
+
+import Combine
+import UIKit
+import WebKit
+
+final class LectureViewController: UIViewController {
+    
+    private var viewModel: EducationViewModel
+    private var cancellables = Set<AnyCancellable>()
+    private let webView = WKWebView()
+    
+    init(viewModel: EducationViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpConstraints()
+        setUpStyle()
+        loadWebPage()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        navigationController?.navigationBar.prefersLargeTitles = true
+    }
+    
+    private func setUpConstraints() {
+        let safeArea = view.safeAreaLayoutGuide
+        
+        view.addSubview(webView)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+        ])
+    }
+    
+    private func setUpStyle() {
+        view.backgroundColor = .white
+    }
+    
+    private func loadWebPage() {
+        Task {
+//            guard let url = try await viewModel.getLecture() else { return }
+//            guard let stringToURL = URL(string: url) else { return }
+            guard let stringToURL = URL(string: "http://naver.com") else { return }
+            let URLToRequest = URLRequest(url: stringToURL)
+            webView.load(URLToRequest)
+            navigationController?.navigationBar.prefersLargeTitles = false
+        }
+    }
+}

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
@@ -14,7 +14,6 @@ protocol EducationMainViewControllerDelegate: AnyObject {
 
 final class EducationMainViewController: UIViewController {
 
-    let eduStatus: [String] = ["Completed", "Not Completed", "Not Completed"]
     private var certificateStatusView = CertificateStatusView()
     private let progressView = EducationProgressView()
     private let educationCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -30,7 +29,6 @@ final class EducationMainViewController: UIViewController {
         setUpConstraints()
         setUpStyle()
         setUpCollectionView()
-        setUpDelegate()
         bind(to: viewModel)
     }
     
@@ -73,7 +71,7 @@ final class EducationMainViewController: UIViewController {
         navBar.prefersLargeTitles = true
         navBar.topItem?.title = "Education"
         navBar.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.mainRed]
-        self.navigationController?.navigationItem.largeTitleDisplayMode = .automatic
+        self.navigationController?.navigationBar.prefersLargeTitles = true
     }
     
     private func setUpCollectionView() {
@@ -82,9 +80,6 @@ final class EducationMainViewController: UIViewController {
         educationCollectionView.register(EducationCollectionViewCell.self, forCellWithReuseIdentifier: EducationCollectionViewCell.identifier)
     }
     
-    private func setUpDelegate() {
-        
-    }
     private func bind(to viewModel: EducationViewModel) {
         
         let output = viewModel.transform()
@@ -157,7 +152,7 @@ extension EducationMainViewController: UICollectionViewDelegateFlowLayout {
     func navigateTo(index: Int) {
         var vc: UIViewController
         if index == 0 {
-            vc = UIViewController()
+            vc = LectureViewController(viewModel: viewModel)
             navigationController?.pushViewController(vc, animated: true)
         } else if index == 1 {
             let temp = EducationQuizViewController()


### PR DESCRIPTION
### One line Description
교육 탭 강의 수강 페이지에서의 WebView 및 서버 URL을 구현

### Work Detail(Optional)
**임시 URL로 웹뷰가 정상적으로 작동하는지 테스트했습니다.**
*빌드 후 테스트 시 웹뷰가 정상적으로 띄워집니다.*

|실행 영상|
|:---:|
|![](https://user-images.githubusercontent.com/96641477/227271579-4f86ad7e-1838-4dd1-b764-c72f897cb069.mp4)|

### NOTICE: Navigation Large Title
- `EducationMainViewController` -> `LectureViewController`로 전환될 때 Large Title을 해제하고 싶은 경우에 대해 아래와 같은 코드를 작성한다.
```swift
// AViewController -> BViewController 의 경우 BViewController.swift에 해당 코드 삽입
 override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(true)
        navigationController?.navigationBar.prefersLargeTitles = false
    }
    override func viewWillDisappear(_ animated: Bool) {
        super.viewWillDisappear(true)
        navigationController?.navigationBar.prefersLargeTitles = true
    }
```

### Issue
- #37 
- Close #37 