### PR TITLE
[FEAT] #32 교육 로직 구현 - 서버 통신 파트

### DIFF
--- a/CPR2U/CPR2U.xcodeproj/project.pbxproj
+++ b/CPR2U/CPR2U.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXBuildFile section */
 		24CEFDC9C69B23440E07EF1C /* Pods_CPR2U.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDF82C0EF3B44D7FED6D1535 /* Pods_CPR2U.framework */; };
 		3A22BF4329BC9122004411BE /* URLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF4229BC9122004411BE /* URLs.swift */; };
-		3A22BF5029BCCE07004411BE /* SignEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF4F29BCCE07004411BE /* SignEndPoint.swift */; };
+		3A22BF5029BCCE07004411BE /* AuthEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF4F29BCCE07004411BE /* AuthEndPoint.swift */; };
 		3A22BF5229BCD6B8004411BE /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF5129BCD6B8004411BE /* AuthManager.swift */; };
 		3A22BF5529BCEAC8004411BE /* NetworkResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF5429BCEAC8004411BE /* NetworkResponse.swift */; };
 		3A22BF5729BCEBA2004411BE /* APIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF5629BCEBA2004411BE /* APIError.swift */; };
-		3A22BF5D29BCF159004411BE /* Sign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF5C29BCF159004411BE /* Sign.swift */; };
+		3A22BF5D29BCF159004411BE /* Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF5C29BCF159004411BE /* Auth.swift */; };
 		3A22BF5F29BDFF1A004411BE /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF5E29BDFF1A004411BE /* NetworkRequest.swift */; };
 		3A22BF6129BDFF3B004411BE /* HttpMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF6029BDFF3B004411BE /* HttpMethod.swift */; };
 		3A22BF6529BE01AB004411BE /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A22BF6429BE01AB004411BE /* EndPoint.swift */; };
@@ -41,6 +41,11 @@
 		3A396BA529CA0646009B0545 /* UIWindow+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BA429CA0646009B0545 /* UIWindow+.swift */; };
 		3A396BAA29CA0A07009B0545 /* TabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BA929CA0A07009B0545 /* TabBarViewController.swift */; };
 		3A396BB229CAF0DA009B0545 /* DeviceTokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BB129CAF0DA009B0545 /* DeviceTokenManager.swift */; };
+		3A396BB529CB1F31009B0545 /* EducationEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BB429CB1F31009B0545 /* EducationEndPoint.swift */; };
+		3A396BB729CB1F38009B0545 /* EducationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BB629CB1F38009B0545 /* EducationManager.swift */; };
+		3A396BB929CB2686009B0545 /* Education.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BB829CB2686009B0545 /* Education.swift */; };
+		3A396BBB29CB2C87009B0545 /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BBA29CB2C87009B0545 /* TestViewController.swift */; };
+		3A396BBC29CB2E39009B0545 /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A396BAC29CA138A009B0545 /* Private.plist */; };
 		3A50F39329BF51F800DC1E29 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A50F39229BF51F800DC1E29 /* UIButton+.swift */; };
 		3A5C390E29C0844700378015 /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3A5C390D29C0844700378015 /* CombineCocoa */; };
 		3A5C391029C08C8900378015 /* QuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5C390F29C08C8900378015 /* QuizViewModel.swift */; };
@@ -80,11 +85,11 @@
 /* Begin PBXFileReference section */
 		2B9F1310FB54413A2CCE87FD /* Pods-CPR2U.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CPR2U.debug.xcconfig"; path = "Target Support Files/Pods-CPR2U/Pods-CPR2U.debug.xcconfig"; sourceTree = "<group>"; };
 		3A22BF4229BC9122004411BE /* URLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLs.swift; sourceTree = "<group>"; };
-		3A22BF4F29BCCE07004411BE /* SignEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignEndPoint.swift; sourceTree = "<group>"; };
+		3A22BF4F29BCCE07004411BE /* AuthEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthEndPoint.swift; sourceTree = "<group>"; };
 		3A22BF5129BCD6B8004411BE /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		3A22BF5429BCEAC8004411BE /* NetworkResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResponse.swift; sourceTree = "<group>"; };
 		3A22BF5629BCEBA2004411BE /* APIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIError.swift; sourceTree = "<group>"; };
-		3A22BF5C29BCF159004411BE /* Sign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sign.swift; sourceTree = "<group>"; };
+		3A22BF5C29BCF159004411BE /* Auth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Auth.swift; sourceTree = "<group>"; };
 		3A22BF5E29BDFF1A004411BE /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
 		3A22BF6029BDFF3B004411BE /* HttpMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpMethod.swift; sourceTree = "<group>"; };
 		3A22BF6429BE01AB004411BE /* EndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPoint.swift; sourceTree = "<group>"; };
@@ -113,6 +118,10 @@
 		3A396BA929CA0A07009B0545 /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
 		3A396BAC29CA138A009B0545 /* Private.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Private.plist; sourceTree = "<group>"; };
 		3A396BB129CAF0DA009B0545 /* DeviceTokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenManager.swift; sourceTree = "<group>"; };
+		3A396BB429CB1F31009B0545 /* EducationEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationEndPoint.swift; sourceTree = "<group>"; };
+		3A396BB629CB1F38009B0545 /* EducationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationManager.swift; sourceTree = "<group>"; };
+		3A396BB829CB2686009B0545 /* Education.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Education.swift; sourceTree = "<group>"; };
+		3A396BBA29CB2C87009B0545 /* TestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewController.swift; sourceTree = "<group>"; };
 		3A50F39229BF51F800DC1E29 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		3A5C390F29C08C8900378015 /* QuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
 		3A5C391229C0948F00378015 /* Quiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quiz.swift; sourceTree = "<group>"; };
@@ -235,7 +244,8 @@
 		3A22BF4029BC90D6004411BE /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				3A22BF4E29BCCDF7004411BE /* Sign */,
+				3A22BF4E29BCCDF7004411BE /* Auth */,
+				3A396BB329CB1F0A009B0545 /* Education */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -249,13 +259,13 @@
 			path = Constants;
 			sourceTree = "<group>";
 		};
-		3A22BF4E29BCCDF7004411BE /* Sign */ = {
+		3A22BF4E29BCCDF7004411BE /* Auth */ = {
 			isa = PBXGroup;
 			children = (
-				3A22BF4F29BCCE07004411BE /* SignEndPoint.swift */,
+				3A22BF4F29BCCE07004411BE /* AuthEndPoint.swift */,
 				3A22BF5129BCD6B8004411BE /* AuthManager.swift */,
 			);
-			path = Sign;
+			path = Auth;
 			sourceTree = "<group>";
 		};
 		3A22BF5329BCE990004411BE /* APIServices */ = {
@@ -283,7 +293,8 @@
 		3A22BF5929BCF0AA004411BE /* DTO */ = {
 			isa = PBXGroup;
 			children = (
-				3A22BF5C29BCF159004411BE /* Sign.swift */,
+				3A22BF5C29BCF159004411BE /* Auth.swift */,
+				3A396BB829CB2686009B0545 /* Education.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -367,6 +378,15 @@
 			path = Shared;
 			sourceTree = "<group>";
 		};
+		3A396BB329CB1F0A009B0545 /* Education */ = {
+			isa = PBXGroup;
+			children = (
+				3A396BB429CB1F31009B0545 /* EducationEndPoint.swift */,
+				3A396BB629CB1F38009B0545 /* EducationManager.swift */,
+			);
+			path = Education;
+			sourceTree = "<group>";
+		};
 		3A5C391129C0948600378015 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -446,6 +466,7 @@
 		3ADE725029B9D53E00EEE19C /* Education */ = {
 			isa = PBXGroup;
 			children = (
+				3A396BBA29CB2C87009B0545 /* TestViewController.swift */,
 				3ADE725C29BA3BC000EEE19C /* Main */,
 				3ADE725D29BA3BCD00EEE19C /* Quiz */,
 				3ADE725E29BA3BDB00EEE19C /* Pose */,
@@ -567,6 +588,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A396BBC29CB2E39009B0545 /* Private.plist in Resources */,
 				3AA636C929B08402006BB5EF /* NotoSans-Regular.ttf in Resources */,
 				3AA636C829B08402006BB5EF /* NotoSans-Bold.ttf in Resources */,
 				3A324CD829C60E6400165E2E /* movenet_thunder.tflite in Resources */,
@@ -611,11 +633,13 @@
 				3A22BF6529BE01AB004411BE /* EndPoint.swift in Sources */,
 				3ADE725629B9EA3200EEE19C /* EducationProgressView.swift in Sources */,
 				3ADE726029BB03A100EEE19C /* EducationQuizViewController.swift in Sources */,
-				3A22BF5D29BCF159004411BE /* Sign.swift in Sources */,
+				3A22BF5D29BCF159004411BE /* Auth.swift in Sources */,
 				3A324CDB29C60E8F00165E2E /* PoseConfig.swift in Sources */,
 				3A396BA329C9EDAB009B0545 /* UserDefaultsManager.swift in Sources */,
 				3A324CDD29C60E9800165E2E /* MoveNet.swift in Sources */,
+				3A396BBB29CB2C87009B0545 /* TestViewController.swift in Sources */,
 				3ADE725229B9D55100EEE19C /* EducationMainViewController.swift in Sources */,
+				3A396BB729CB1F38009B0545 /* EducationManager.swift in Sources */,
 				3ADE726229BB047300EEE19C /* QuizChoiceView.swift in Sources */,
 				3AA636F529B61D67006BB5EF /* UIViewController+.swift in Sources */,
 				3A396B8F29C89DA3009B0545 /* EducationViewModel.swift in Sources */,
@@ -623,6 +647,7 @@
 				3A5C391029C08C8900378015 /* QuizViewModel.swift in Sources */,
 				3ADE726629BB04C900EEE19C /* QuizQuestionView.swift in Sources */,
 				3A22BF5529BCEAC8004411BE /* NetworkResponse.swift in Sources */,
+				3A396BB929CB2686009B0545 /* Education.swift in Sources */,
 				3AA636D929B36C76006BB5EF /* NicknameVertificationViewController.swift in Sources */,
 				3AA636ED29B5E816006BB5EF /* AuthViewModel.swift in Sources */,
 				3A324CDF29C60E9F00165E2E /* PoseData.swift in Sources */,
@@ -650,7 +675,8 @@
 				3ADE724F29B9D4AB00EEE19C /* Constraints.swift in Sources */,
 				3A324CE529C6104400165E2E /* CVPixelBuffer+TFLite.swift in Sources */,
 				3AA636C229B07C5F006BB5EF /* UIColor+.swift in Sources */,
-				3A22BF5029BCCE07004411BE /* SignEndPoint.swift in Sources */,
+				3A22BF5029BCCE07004411BE /* AuthEndPoint.swift in Sources */,
+				3A396BB529CB1F31009B0545 /* EducationEndPoint.swift in Sources */,
 				3AA636AE29AE5055006BB5EF /* AppDelegate.swift in Sources */,
 				3A396BA129C9E906009B0545 /* AutoLoginViewController.swift in Sources */,
 				3AA636F129B5F1C8006BB5EF /* UIControl+.swift in Sources */,

--- a/CPR2U/CPR2U.xcodeproj/project.pbxproj
+++ b/CPR2U/CPR2U.xcodeproj/project.pbxproj
@@ -44,9 +44,8 @@
 		3A396BB729CB1F38009B0545 /* EducationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BB629CB1F38009B0545 /* EducationManager.swift */; };
 		3A396BB929CB2686009B0545 /* Education.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BB829CB2686009B0545 /* Education.swift */; };
 		3A396BBB29CB2C87009B0545 /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BBA29CB2C87009B0545 /* TestViewController.swift */; };
-		3A396BBC29CB2E39009B0545 /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A396BAC29CA138A009B0545 /* Private.plist */; };
-		3A396BC329CCA563009B0545 /* LectureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BC229CCA563009B0545 /* LectureViewController.swift */; };
 		3A396BBE29CC3D32009B0545 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A396BBD29CC3D32009B0545 /* GoogleService-Info.plist */; };
+		3A396BC329CCA563009B0545 /* LectureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BC229CCA563009B0545 /* LectureViewController.swift */; };
 		3A50F39329BF51F800DC1E29 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A50F39229BF51F800DC1E29 /* UIButton+.swift */; };
 		3A5C390E29C0844700378015 /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3A5C390D29C0844700378015 /* CombineCocoa */; };
 		3A5C391029C08C8900378015 /* QuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5C390F29C08C8900378015 /* QuizViewModel.swift */; };
@@ -122,8 +121,8 @@
 		3A396BB629CB1F38009B0545 /* EducationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationManager.swift; sourceTree = "<group>"; };
 		3A396BB829CB2686009B0545 /* Education.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Education.swift; sourceTree = "<group>"; };
 		3A396BBA29CB2C87009B0545 /* TestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewController.swift; sourceTree = "<group>"; };
-		3A396BC229CCA563009B0545 /* LectureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureViewController.swift; sourceTree = "<group>"; };
 		3A396BBD29CC3D32009B0545 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		3A396BC229CCA563009B0545 /* LectureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureViewController.swift; sourceTree = "<group>"; };
 		3A50F39229BF51F800DC1E29 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		3A5C390F29C08C8900378015 /* QuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
 		3A5C391229C0948F00378015 /* Quiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quiz.swift; sourceTree = "<group>"; };
@@ -599,7 +598,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3A396BBC29CB2E39009B0545 /* Private.plist in Resources */,
 				3AA636C929B08402006BB5EF /* NotoSans-Regular.ttf in Resources */,
 				3AA636C829B08402006BB5EF /* NotoSans-Bold.ttf in Resources */,
 				3A324CD829C60E6400165E2E /* movenet_thunder.tflite in Resources */,

--- a/CPR2U/CPR2U.xcodeproj/project.pbxproj
+++ b/CPR2U/CPR2U.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		3A396BB929CB2686009B0545 /* Education.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BB829CB2686009B0545 /* Education.swift */; };
 		3A396BBB29CB2C87009B0545 /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BBA29CB2C87009B0545 /* TestViewController.swift */; };
 		3A396BBC29CB2E39009B0545 /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A396BAC29CA138A009B0545 /* Private.plist */; };
+		3A396BC329CCA563009B0545 /* LectureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BC229CCA563009B0545 /* LectureViewController.swift */; };
 		3A50F39329BF51F800DC1E29 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A50F39229BF51F800DC1E29 /* UIButton+.swift */; };
 		3A5C390E29C0844700378015 /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3A5C390D29C0844700378015 /* CombineCocoa */; };
 		3A5C391029C08C8900378015 /* QuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5C390F29C08C8900378015 /* QuizViewModel.swift */; };
@@ -122,6 +123,7 @@
 		3A396BB629CB1F38009B0545 /* EducationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationManager.swift; sourceTree = "<group>"; };
 		3A396BB829CB2686009B0545 /* Education.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Education.swift; sourceTree = "<group>"; };
 		3A396BBA29CB2C87009B0545 /* TestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewController.swift; sourceTree = "<group>"; };
+		3A396BC229CCA563009B0545 /* LectureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureViewController.swift; sourceTree = "<group>"; };
 		3A50F39229BF51F800DC1E29 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		3A5C390F29C08C8900378015 /* QuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
 		3A5C391229C0948F00378015 /* Quiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quiz.swift; sourceTree = "<group>"; };
@@ -387,6 +389,14 @@
 			path = Education;
 			sourceTree = "<group>";
 		};
+		3A396BC129CCA4F1009B0545 /* Lecture */ = {
+			isa = PBXGroup;
+			children = (
+				3A396BC229CCA563009B0545 /* LectureViewController.swift */,
+			);
+			path = Lecture;
+			sourceTree = "<group>";
+		};
 		3A5C391129C0948600378015 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -468,6 +478,7 @@
 			children = (
 				3A396BBA29CB2C87009B0545 /* TestViewController.swift */,
 				3ADE725C29BA3BC000EEE19C /* Main */,
+				3A396BC129CCA4F1009B0545 /* Lecture */,
 				3ADE725D29BA3BCD00EEE19C /* Quiz */,
 				3ADE725E29BA3BDB00EEE19C /* Pose */,
 			);
@@ -639,6 +650,7 @@
 				3A324CDD29C60E9800165E2E /* MoveNet.swift in Sources */,
 				3A396BBB29CB2C87009B0545 /* TestViewController.swift in Sources */,
 				3ADE725229B9D55100EEE19C /* EducationMainViewController.swift in Sources */,
+				3A396BC329CCA563009B0545 /* LectureViewController.swift in Sources */,
 				3A396BB729CB1F38009B0545 /* EducationManager.swift in Sources */,
 				3ADE726229BB047300EEE19C /* QuizChoiceView.swift in Sources */,
 				3AA636F529B61D67006BB5EF /* UIViewController+.swift in Sources */,

--- a/CPR2U/CPR2U.xcodeproj/project.pbxproj
+++ b/CPR2U/CPR2U.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		3A396B8F29C89DA3009B0545 /* EducationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B8E29C89DA3009B0545 /* EducationViewModel.swift */; };
 		3A396B9129C8A87D009B0545 /* ViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B9029C8A87D009B0545 /* ViewModelProtocol.swift */; };
 		3A396B9329C97E31009B0545 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396B9229C97E31009B0545 /* UIView+.swift */; };
-		3A396B9829C9D2F4009B0545 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A396B9729C9D2F4009B0545 /* GoogleService-Info.plist */; };
 		3A396B9B29C9D395009B0545 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 3A396B9A29C9D395009B0545 /* FirebaseMessaging */; };
 		3A396BA129C9E906009B0545 /* AutoLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BA029C9E906009B0545 /* AutoLoginViewController.swift */; };
 		3A396BA329C9EDAB009B0545 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BA229C9EDAB009B0545 /* UserDefaultsManager.swift */; };
@@ -47,6 +46,7 @@
 		3A396BBB29CB2C87009B0545 /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BBA29CB2C87009B0545 /* TestViewController.swift */; };
 		3A396BBC29CB2E39009B0545 /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A396BAC29CA138A009B0545 /* Private.plist */; };
 		3A396BC329CCA563009B0545 /* LectureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A396BC229CCA563009B0545 /* LectureViewController.swift */; };
+		3A396BBE29CC3D32009B0545 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3A396BBD29CC3D32009B0545 /* GoogleService-Info.plist */; };
 		3A50F39329BF51F800DC1E29 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A50F39229BF51F800DC1E29 /* UIButton+.swift */; };
 		3A5C390E29C0844700378015 /* CombineCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 3A5C390D29C0844700378015 /* CombineCocoa */; };
 		3A5C391029C08C8900378015 /* QuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5C390F29C08C8900378015 /* QuizViewModel.swift */; };
@@ -112,7 +112,6 @@
 		3A396B9029C8A87D009B0545 /* ViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelProtocol.swift; sourceTree = "<group>"; };
 		3A396B9229C97E31009B0545 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		3A396B9629C9C648009B0545 /* CPR2U.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CPR2U.entitlements; sourceTree = "<group>"; };
-		3A396B9729C9D2F4009B0545 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3A396BA029C9E906009B0545 /* AutoLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoLoginViewController.swift; sourceTree = "<group>"; };
 		3A396BA229C9EDAB009B0545 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		3A396BA429CA0646009B0545 /* UIWindow+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+.swift"; sourceTree = "<group>"; };
@@ -124,6 +123,7 @@
 		3A396BB829CB2686009B0545 /* Education.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Education.swift; sourceTree = "<group>"; };
 		3A396BBA29CB2C87009B0545 /* TestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewController.swift; sourceTree = "<group>"; };
 		3A396BC229CCA563009B0545 /* LectureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LectureViewController.swift; sourceTree = "<group>"; };
+		3A396BBD29CC3D32009B0545 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3A50F39229BF51F800DC1E29 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		3A5C390F29C08C8900378015 /* QuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizViewModel.swift; sourceTree = "<group>"; };
 		3A5C391229C0948F00378015 /* Quiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Quiz.swift; sourceTree = "<group>"; };
@@ -439,7 +439,7 @@
 				3AA636B829AE5057006BB5EF /* LaunchScreen.storyboard */,
 				3AA636BB29AE5057006BB5EF /* Info.plist */,
 				3A396BAC29CA138A009B0545 /* Private.plist */,
-				3A396B9729C9D2F4009B0545 /* GoogleService-Info.plist */,
+				3A396BBD29CC3D32009B0545 /* GoogleService-Info.plist */,
 			);
 			path = CPR2U;
 			sourceTree = "<group>";
@@ -605,7 +605,7 @@
 				3A324CD829C60E6400165E2E /* movenet_thunder.tflite in Resources */,
 				3AA636BA29AE5057006BB5EF /* LaunchScreen.storyboard in Resources */,
 				3AA636B729AE5057006BB5EF /* Assets.xcassets in Resources */,
-				3A396B9829C9D2F4009B0545 /* GoogleService-Info.plist in Resources */,
+				3A396BBE29CC3D32009B0545 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CPR2U/CPR2U/Application/AppDelegate.swift
+++ b/CPR2U/CPR2U/Application/AppDelegate.swift
@@ -56,7 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let deviceTokenString = deviceToken.map { String(format: "%02x", $0) }.joined()
 //        DeviceTokenManager.deviceToken = deviceTokenString
-        DeviceTokenManager.deviceToken = "non"
+        DeviceTokenManager.deviceToken = "test"
         Messaging.messaging().apnsToken = deviceToken
     }
     

--- a/CPR2U/CPR2U/Application/AppDelegate.swift
+++ b/CPR2U/CPR2U/Application/AppDelegate.swift
@@ -55,9 +55,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         let deviceTokenString = deviceToken.map { String(format: "%02x", $0) }.joined()
-        DeviceTokenManager.deviceToken = deviceTokenString
+//        DeviceTokenManager.deviceToken = deviceTokenString
+        DeviceTokenManager.deviceToken = "non"
         Messaging.messaging().apnsToken = deviceToken
     }
+    
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
     }
     

--- a/CPR2U/CPR2U/Application/SceneDelegate.swift
+++ b/CPR2U/CPR2U/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
         
         self.window = window
-        let navVC = UINavigationController(rootViewController: EducationMainViewController())
+//        let navVC = UINavigationController(rootViewController: EducationMainViewController())
         let vc = AutoLoginViewController()
         window.rootViewController =  vc
         window.backgroundColor = .white

--- a/CPR2U/CPR2U/Data/DTO/Auth.swift
+++ b/CPR2U/CPR2U/Data/DTO/Auth.swift
@@ -1,5 +1,5 @@
 //
-//  Sign.swift
+//  AuthEndPoint.swift
 //  CPR2U
 //
 //  Created by 황정현 on 2023/03/12.

--- a/CPR2U/CPR2U/Data/DTO/Education.swift
+++ b/CPR2U/CPR2U/Data/DTO/Education.swift
@@ -1,0 +1,61 @@
+//
+//  Education.swift
+//  CPR2U
+//
+//  Created by 황정현 on 2023/03/22.
+//
+
+import Foundation
+
+struct QuizResult: Codable { }
+
+struct LectureProgressResult: Codable { }
+
+struct PosturePracticeResult: Codable { }
+
+struct UserInfo: Codable {
+    let nickname: String
+    let angel_status: Int
+    let progress_percent: Double
+    let is_lecture_completed: Int
+    let last_lecture_title: String
+    let is_quiz_completed: Int
+    let is_posture_completed: Int
+    let days_left_until_expiration: Int?
+}
+
+struct QuizInfoList: Codable {
+    let list: [QuizInfo]
+}
+
+struct QuizInfo: Codable {
+    let index: Int
+    let question: String
+    let type: Int
+    let answer: Int
+    let reason: String
+    let answer_content: String
+    let answer_list: [AnswerInfo]
+}
+
+struct AnswerInfo: Codable {
+    let id: Int
+    let content: String
+}
+
+struct LectureProgressInfo: Codable {
+    let current_step: Int
+    let lecture_list: [LectureInfo]
+}
+
+struct LectureInfo: Codable {
+    let id: Int
+    let step: Int
+    let title: String
+    let description: String
+    let video_url: String
+}
+
+struct PostureLectureInfo: Codable {
+    let video_url: String
+}

--- a/CPR2U/CPR2U/Data/DTO/Education.swift
+++ b/CPR2U/CPR2U/Data/DTO/Education.swift
@@ -24,10 +24,6 @@ struct UserInfo: Codable {
     let days_left_until_expiration: Int?
 }
 
-struct QuizInfoList: Codable {
-    let list: [QuizInfo]
-}
-
 struct QuizInfo: Codable {
     let index: Int
     let question: String

--- a/CPR2U/CPR2U/Scene/Education/Lecture/LectureViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Lecture/LectureViewController.swift
@@ -1,0 +1,70 @@
+//
+//  LectureViewController.swift
+//  CPR2U
+//
+//  Created by 황정현 on 2023/03/24.
+//
+
+import Combine
+import UIKit
+import WebKit
+
+final class LectureViewController: UIViewController {
+    
+    private var viewModel: EducationViewModel
+    private var cancellables = Set<AnyCancellable>()
+    private let webView = WKWebView()
+    
+    init(viewModel: EducationViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUpConstraints()
+        setUpStyle()
+        loadWebPage()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(true)
+        navigationController?.navigationBar.prefersLargeTitles = false
+    }
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        navigationController?.navigationBar.prefersLargeTitles = true
+    }
+    
+    private func setUpConstraints() {
+        let safeArea = view.safeAreaLayoutGuide
+        
+        view.addSubview(webView)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+        ])
+    }
+    
+    private func setUpStyle() {
+        view.backgroundColor = .white
+    }
+    
+    private func loadWebPage() {
+        Task {
+//            guard let url = try await viewModel.getLecture() else { return }
+//            guard let stringToURL = URL(string: url) else { return }
+            guard let stringToURL = URL(string: "http://naver.com") else { return }
+            let URLToRequest = URLRequest(url: stringToURL)
+            webView.load(URLToRequest)
+        }
+    }
+}

--- a/CPR2U/CPR2U/Scene/Education/Lecture/LectureViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Lecture/LectureViewController.swift
@@ -113,10 +113,13 @@ final class LectureViewController: UIViewController {
     private func bind(viewModel: EducationViewModel) {
         noticeView.confirmButton.tapPublisher.sink { [weak self] in
             Task {
-                try await viewModel.saveLectureProgress()
+                _ = try await viewModel.saveLectureProgress()
+                self?.noticeView.noticeDisappear()
+                if let vc = self?.navigationController?.viewControllers[0] as? EducationMainViewController {
+                    vc.educationCollectionView.reloadData()
+                }
+                self?.navigationController?.popViewController(animated: true)
             }
-            self?.noticeView.noticeDisappear()
-            self?.navigationController?.popViewController(animated: true)
         }.store(in: &cancellables)
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
@@ -28,8 +28,10 @@ final class EducationMainViewController: UIViewController {
         
         setUpConstraints()
         setUpStyle()
-        setUpCollectionView()
-        bind(to: viewModel)
+        Task {
+            await bind(to:viewModel)
+            setUpCollectionView()
+        }
     }
     
     private func setUpConstraints() {
@@ -86,6 +88,7 @@ final class EducationMainViewController: UIViewController {
         
         output.certificateStatus?.sink { status in
             self.certificateStatusView.setUpStatus(as: status.status, leftDay: status.leftDay)
+            print("HERE!")
         }.store(in: &cancellables)
         
         output.nickname?.sink { nickname in
@@ -95,6 +98,8 @@ final class EducationMainViewController: UIViewController {
         output.progressPercent?.sink { progress in
             self.progressView.setUpProgress(as: progress)
         }.store(in: &cancellables)
+        
+        output.
     }
 }
 
@@ -108,6 +113,7 @@ extension EducationMainViewController: UICollectionViewDataSource {
         
         cell.setUpEducationNameLabel(as: viewModel.educationName()[indexPath.row])
         cell.setUpDescriptionLabel(as: viewModel.educationDescription()[indexPath.row])
+        print(viewModel.educationStatus().count)
         cell.setUpStatus(isCompleted: viewModel.educationStatus()[indexPath.row])
         
         return cell
@@ -161,7 +167,7 @@ extension EducationMainViewController: UICollectionViewDelegateFlowLayout {
             vc.modalPresentationStyle = .overFullScreen
             self.present(vc, animated: true)
         } else {
-            vc = PracticeExplainViewController()
+            vc = PracticeExplainViewController(viewModel: viewModel)
             navigationController?.pushViewController(vc, animated: true)
         }
     }
@@ -170,7 +176,8 @@ extension EducationMainViewController: UICollectionViewDelegateFlowLayout {
 extension EducationMainViewController: EducationMainViewControllerDelegate {
     func updateUserEducationStatus() {
         Task {
-            try await viewModel.receiveEducationStatus()
+            let userInfo = try await viewModel.receiveEducationStatus()
+            viewModel.updateInput(data: userInfo)
         }
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
@@ -23,12 +23,15 @@ final class EducationMainViewController: UIViewController {
     
     private weak var delegate: EducationMainViewControllerDelegate?
     
+    private lazy var noticeView = CustomNoticeView(noticeAs: .certificate)
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         setUpConstraints()
         setUpStyle()
         bind(to:viewModel)
+        noticeView.setCertificateNotice()
         DispatchQueue.main.async { [weak self] in
             self?.setUpCollectionView()
         }
@@ -41,7 +44,8 @@ final class EducationMainViewController: UIViewController {
         [
             certificateStatusView,
             progressView,
-            educationCollectionView
+            educationCollectionView,
+            noticeView
         ].forEach({
             view.addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
@@ -67,6 +71,13 @@ final class EducationMainViewController: UIViewController {
             educationCollectionView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
             educationCollectionView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor)
         ])
+        
+        NSLayoutConstraint.activate([
+            noticeView.topAnchor.constraint(equalTo: view.topAnchor),
+            noticeView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            noticeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            noticeView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
     }
     
     private func setUpStyle() {
@@ -89,6 +100,10 @@ final class EducationMainViewController: UIViewController {
             
             output.certificateStatus?.sink { status in
                 self.certificateStatusView.setUpStatus(as: status.status, leftDay: status.leftDay)
+                if status.status == .acquired && UserDefaultsManager.isCertificateNotice == false {
+                    self.noticeView.noticeAppear()
+                    UserDefaultsManager.isCertificateNotice = true
+                }
             }.store(in: &cancellables)
             
             output.nickname?.sink { nickname in
@@ -116,7 +131,6 @@ extension EducationMainViewController: UICollectionViewDataSource {
         
         cell.setUpEducationNameLabel(as: viewModel.educationName()[indexPath.row])
         cell.setUpDescriptionLabel(as: viewModel.educationDescription()[indexPath.row])
-        print(viewModel.educationStatus().count)
         cell.setUpStatus(isCompleted: viewModel.educationStatus()[indexPath.row].value)
         
         return cell

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
@@ -14,7 +14,6 @@ protocol EducationMainViewControllerDelegate: AnyObject {
 
 final class EducationMainViewController: UIViewController {
 
-    let eduStatus: [String] = ["Completed", "Not Completed", "Not Completed"]
     private var certificateStatusView = CertificateStatusView()
     private let progressView = EducationProgressView()
     private let educationCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -30,7 +29,6 @@ final class EducationMainViewController: UIViewController {
         setUpConstraints()
         setUpStyle()
         setUpCollectionView()
-        setUpDelegate()
         bind(to: viewModel)
     }
     
@@ -73,7 +71,7 @@ final class EducationMainViewController: UIViewController {
         navBar.prefersLargeTitles = true
         navBar.topItem?.title = "Education"
         navBar.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.mainRed]
-        self.navigationController?.navigationItem.largeTitleDisplayMode = .automatic
+        self.navigationController?.navigationBar.prefersLargeTitles = true
     }
     
     private func setUpCollectionView() {
@@ -82,9 +80,6 @@ final class EducationMainViewController: UIViewController {
         educationCollectionView.register(EducationCollectionViewCell.self, forCellWithReuseIdentifier: EducationCollectionViewCell.identifier)
     }
     
-    private func setUpDelegate() {
-        
-    }
     private func bind(to viewModel: EducationViewModel) {
         
         let output = viewModel.transform()
@@ -157,7 +152,7 @@ extension EducationMainViewController: UICollectionViewDelegateFlowLayout {
     func navigateTo(index: Int) {
         var vc: UIViewController
         if index == 0 {
-            vc = UIViewController()
+            vc = LectureViewController(viewModel: viewModel)
             navigationController?.pushViewController(vc, animated: true)
         } else if index == 1 {
             let temp = EducationQuizViewController()

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationViewModel.swift
@@ -144,8 +144,6 @@ final class EducationViewModel: OutputOnlyViewModelType {
     }
     
     func initialize() async throws -> Input? {
-        
-        print("Initializee....")
         let result = Task { () -> Input? in
             let eduResult = try await self.eduManager.getEducationProgress()
             guard let data = eduResult.data else { return nil }

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationViewModel.swift
@@ -5,8 +5,9 @@
 //  Created by 황정현 on 2023/03/20.
 //
 
-import Foundation
 import Combine
+import UIKit
+
 
 enum AngelStatus: Int {
     case acquired
@@ -34,33 +35,38 @@ enum AngelStatus: Int {
     }
 }
 
+enum TimerType: Int {
+    case lecture = 5 // 3000
+    case posture = 10 // 120
+    case other = 0
+}
+
 final class EducationViewModel: OutputOnlyViewModelType {
     
     private let eduManager: EducationManager
+    
     private let eduName: [String] = ["Lecture" , "Quiz", "Pose Practice"]
     private let eduDescription: [String] = ["Video lecture for CPR angel certificate", "Let’s check your CPR study", "Posture practice to get CPR angel certificate"]
-    private var eduStatusArr:[Bool] = []
     private var input: Input?
+    
+    private var currentTimerType = TimerType.other
+    let timer = Timer.publish(every: 1, on: .current, in: .common)
     
     init() {
         eduManager = EducationManager(service: APIManager())
-        
         Task {
-            try await receiveEducationStatus()
+            self.input = try await initialize() ?? nil
         }
-        // MARK: API NETWORK
-        let educationStatusArr: [Bool] = [true, false, false]
-        eduStatusArr = educationStatusArr
     }
     
     struct Input {
-        let nickname: String
-        let angelStatus: Int
-        let progressPercent: Float
-        let leftDay: Int?
-        let isLectureCompleted: Bool
-        let isQuizCompleted: Bool
-        let isPostureCompleted: Bool
+        let nickname: CurrentValueSubject<String, Never>
+        let angelStatus: CurrentValueSubject<Int, Never>
+        let progressPercent: CurrentValueSubject<Float, Never>
+        let leftDay: CurrentValueSubject<Int?, Never>
+        let isLectureCompleted: CurrentValueSubject<Bool, Never>
+        let isQuizCompleted: CurrentValueSubject<Bool, Never>
+        let isPostureCompleted: CurrentValueSubject<Bool, Never>
     }
     
     struct CertificateStatus {
@@ -86,16 +92,18 @@ final class EducationViewModel: OutputOnlyViewModelType {
         return eduStatusArr
     }
     
+    func timeLimit() -> Int {
+        currentTimerType.rawValue
+    }
+    
     func transform() -> Output {
-        guard let input = input else { return Output(nickname: nil, certificateStatus: nil, progressPercent: nil) }
-        let nickname: CurrentValueSubject<String, Never> = CurrentValueSubject(input.nickname)
         
         let certificateStatus: CurrentValueSubject<CertificateStatus, Never> = {
-            guard let status = AngelStatus(rawValue: input.angelStatus) else {
+            guard let status = AngelStatus(rawValue: input?.angelStatus.value ?? 2) else {
                 return CurrentValueSubject(CertificateStatus(status: AngelStatus.unacquired, leftDay: nil))
             }
             
-            guard let leftDayNum = input.leftDay else {
+            guard let leftDayNum = input?.leftDay.value else {
                 return CurrentValueSubject(CertificateStatus(status: status, leftDay: nil))
             }
  
@@ -103,28 +111,101 @@ final class EducationViewModel: OutputOnlyViewModelType {
             
         }()
         
-        let progressPercent = input.progressPercent
-        
-        return Output(nickname: nickname, certificateStatus: certificateStatus, progressPercent: CurrentValueSubject(progressPercent))
+        return Output(nickname: input?.nickname, certificateStatus: certificateStatus, progressPercent: input?.progressPercent)
     }
     
-    func receiveEducationStatus() async throws {
+    func updateTimerType(vc: UIViewController) {
+        if (vc as? LectureViewController) != nil {
+            currentTimerType = .lecture
+        } else if (vc as? PosePracticeViewController) != nil {
+            currentTimerType = .posture
+        }
+    }
+    
+    func receiveEducationStatus() async throws -> UserInfo? {
         let result = Task { () -> UserInfo? in
             let eduResult = try await eduManager.getEducationProgress()
             return eduResult.data
         }
         
-        do {
-            let data = try await result.value
+        let data = try await result.value
         
-            let progressPercent = Float(data?.progress_percent ?? 0)
-            let isLectureCompleted = data?.is_lecture_completed == 2
-            let isQuizCompleted = data?.is_quiz_completed == 2
-            let isPostureCompleted = data?.is_posture_completed == 2
-            input = Input(nickname: data?.nickname ?? "", angelStatus: data?.angel_status ?? 0, progressPercent: progressPercent, leftDay: data?.days_left_until_expiration, isLectureCompleted: isLectureCompleted, isQuizCompleted: isQuizCompleted, isPostureCompleted: isPostureCompleted)
+        return data
+    }
+    
+    func initialize() async throws -> Input? {
+        let result = Task { () -> Input? in
+            let eduResult = try await self.eduManager.getEducationProgress()
+            guard let data = eduResult.data else { return nil }
+        
+            let progressPercent = Float(data.progress_percent)
+            let isLectureCompleted = data.is_lecture_completed == 2
+            let isQuizCompleted = data.is_quiz_completed == 2
+            let isPostureCompleted = data.is_posture_completed == 2
+            
             eduStatusArr = [isLectureCompleted, isQuizCompleted, isPostureCompleted]
-        } catch(let error) {
-            print(error)
+            return Input(nickname: CurrentValueSubject(data.nickname), angelStatus: CurrentValueSubject(data.angel_status), progressPercent: CurrentValueSubject(progressPercent), leftDay: CurrentValueSubject(data.days_left_until_expiration), isLectureCompleted: CurrentValueSubject(isLectureCompleted), isQuizCompleted: CurrentValueSubject(isQuizCompleted), isPostureCompleted: CurrentValueSubject(isPostureCompleted))
+        }
+        
+        return try await result.value
+        
+       
+    }
+    
+    // MARK: TEST NOT YET
+    func saveLectureProgress() async throws -> Bool {
+        let result = Task {
+            let eduResult = try await eduManager.saveLectureProgress(lectureId: 1)
+            let userInfo = try await receiveEducationStatus()
+            updateInput(data: userInfo)
+            return eduResult.success
+        }
+        return try await result.value
+    }
+    
+    func savePosturePracticeResult(score: Int) async throws -> Bool {
+        let result = Task {
+            let eduResult = try await eduManager.savePosturePracticeResult(score: score)
+            let userInfo = try await receiveEducationStatus()
+            updateInput(data: userInfo)
+            return eduResult.success
+        }
+        return try await result.value
+    }
+    
+    // MARK: TEST NOT YET
+    func getLecture() async throws -> String? {
+        let result = Task { () -> String? in
+            let eduResult = try await eduManager.getLecture()
+            return eduResult.data?.lecture_list[0].video_url
+        }
+        return try await result.value
+    }
+    
+    // MARK: TEST NOT YET
+    func getPostureLecture() async throws -> String? {
+        let result = Task { () -> String? in
+            let eduResult = try await eduManager.getPostureLecture()
+            return eduResult.data?.video_url
+        }
+        return try await result.value
+    }
+    
+    func updateInput(data: UserInfo?) {
+        let progressPercent = Float(data?.progress_percent ?? 0)
+        let isLectureCompleted = data?.is_lecture_completed == 2
+        let isQuizCompleted = data?.is_quiz_completed == 2
+        let isPostureCompleted = data?.is_posture_completed == 2
+    
+        DispatchQueue.main.async {
+            self.input?.nickname.send(data?.nickname ?? "")
+            self.input?.angelStatus.send(data?.angel_status ?? 0)
+            self.input?.progressPercent.send(progressPercent)
+            self.input?.leftDay.send(data?.days_left_until_expiration ?? nil)
+            self.input?.isLectureCompleted.send(isLectureCompleted)
+            self.input?.isQuizCompleted.send(isQuizCompleted)
+            self.input?.isPostureCompleted.send(isPostureCompleted)
+            self.eduStatusArr = [isLectureCompleted, isQuizCompleted, isPostureCompleted]
         }
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeResultViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeResultViewController.swift
@@ -5,35 +5,77 @@
 //  Created by 황정현 on 2023/03/10.
 //
 
+import Combine
+import CombineCocoa
 import UIKit
 
 final class PosePracticeResultViewController: UIViewController {
-
-    private let compressRateResultView = EvaluationResultView()
-    private let pressDepthResultView = EvaluationResultView()
-    private let handLocationResultView = EvaluationResultView()
-    private let armAngleResultView = EvaluationResultView()
+    private let compressRateResultView: EvaluationResultView = {
+        let view = EvaluationResultView()
+        view.setImage(imgName: "ruler")
+        view.setTitle(title: "Compression Rate")
+        view.setResultLabelText(as: "0.5 per 1 time")
+        view.setDescriptionLabelText(as: "It’s too fast. Little bit Slower")
+        return view
+    }()
+    
+    private let pressDepthResultView: EvaluationResultView = {
+        let view = EvaluationResultView()
+        view.setImage(imgName: "ruler")
+        view.setTitle(title: "Press Depth")
+        view.setResultLabelText(as: "Slightly shallow")
+        view.setDescriptionLabelText(as: "Press little deeper")
+        return view
+    }()
+    
+    private let handLocationResultView: EvaluationResultView = {
+        let view = EvaluationResultView()
+        view.setImage(imgName: "ruler")
+        view.setTitle(title: "Hand Location")
+        view.setResultLabelText(as: "Adequate")
+        view.setDescriptionLabelText(as: "Nice Location!")
+        return view
+    }()
+    
+    private let armAngleResultView: EvaluationResultView = {
+        let view = EvaluationResultView()
+        view.setImage(imgName: "ruler")
+        view.setTitle(title: "Arm Angle")
+        view.setResultLabelText(as: "Adequate")
+        view.setDescriptionLabelText(as: "Nice Angle!")
+        return view
+    }()
+    
     private let finalResultView = AccuracyResultView()
     
-    private let quitButton = UIButton()
+    private let quitButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .mainRed
+        button.layer.cornerRadius = 19
+        button.titleLabel?.font = UIFont(weight: .bold, size: 17)
+        button.setTitleColor(.mainWhite, for: .normal)
+        button.setTitle("QUIT", for: .normal)
+        return button
+    }()
+    
+    private let viewModel: EducationViewModel
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(viewModel: EducationViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setUpOrientation()
         setUpConstraints()
         setUpStyle()
-        setUpResultViews()
-        setUpAction()
-    }
-    
-    private func setUpOrientation() {
-        if let delegate = UIApplication.shared.delegate as? AppDelegate {
-            delegate.orientationLock = .landscapeRight
-        }
-        
-        navigationController?.setNavigationBarHidden(true, animated: true)
-        self.setNeedsUpdateOfSupportedInterfaceOrientations()
+        bind(viewModel: viewModel)
     }
     
     private func setUpConstraints() {
@@ -96,38 +138,18 @@ final class PosePracticeResultViewController: UIViewController {
     }
     
     private func setUpStyle() {
-        quitButton.backgroundColor = .mainRed
-        quitButton.layer.cornerRadius = 19
-        quitButton.titleLabel?.font = UIFont(weight: .bold, size: 17)
-        quitButton.setTitleColor(.mainWhite, for: .normal)
-        quitButton.setTitle("QUIT", for: .normal)
+        view.backgroundColor = .white
     }
     
-    private func setUpResultViews() {
-        
-        compressRateResultView.setImage(imgName: "ruler")
-        compressRateResultView.setTitle(title: "Compression Rate")
-        compressRateResultView.setResultLabelText(as: "0.5 per 1 time")
-        compressRateResultView.setDescriptionLabelText(as: "It’s too fast. Little bit Slower")
-        
-        pressDepthResultView.setImage(imgName: "ruler")
-        pressDepthResultView.setTitle(title: "Press Depth")
-        pressDepthResultView.setResultLabelText(as: "Slightly shallow")
-        pressDepthResultView.setDescriptionLabelText(as: "Press little deeper")
-        
-        handLocationResultView.setImage(imgName: "ruler")
-        handLocationResultView.setTitle(title: "Hand Location")
-        handLocationResultView.setResultLabelText(as: "Adequate")
-        handLocationResultView.setDescriptionLabelText(as: "Nice Location!")
-        
-        armAngleResultView.setImage(imgName: "ruler")
-        armAngleResultView.setTitle(title: "Arm Angle")
-        armAngleResultView.setResultLabelText(as: "Adequate")
-        armAngleResultView.setDescriptionLabelText(as: "Nice Angle!")
-    }
-    
-    private func setUpAction() {
-        
+    private func bind(viewModel: EducationViewModel) {
+        quitButton.tapPublisher.sink { [weak self] _ in
+            self?.setUpOrientation(as: .portrait)
+            Task {
+                try await viewModel.savePosturePracticeResult(score: 90)
+                let rootVC = TabBarViewController(0)
+                await self?.view.window?.setRootViewController(rootVC)
+            }
+        }.store(in: &cancellables)
     }
 
 }

--- a/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeViewController.swift
@@ -85,7 +85,6 @@ final class PosePracticeViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         viewModel.updateTimerType(vc: self)
         setUpOrientation(as: .landscape)
         setUpConstraints()
@@ -103,6 +102,7 @@ final class PosePracticeViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         cameraFeedManager?.stopRunning()
+        viewModel.timer.connect().cancel()
     }
     
     override func viewDidLayoutSubviews() {

--- a/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeViewController.swift
@@ -5,8 +5,9 @@
 //  Created by 황정현 on 2023/03/10.
 //
 
-import UIKit
+import Combine
 import os
+import UIKit
 
 enum Constants {
     // Configs for the TFLite interpreter.
@@ -27,13 +28,11 @@ final class PosePracticeViewController: UIViewController {
         return view
     }()
     
-    private let timeLabel: UILabel = {
+    private lazy var timeLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont(weight: .bold, size: 24)
         label.textColor = .mainBlack
-        
-        // TEST
-        label.text = "01:53"
+        label.text = NumberAsTime(number: viewModel.timeLimit())
         return label
     }()
     private let soundImageView: UIImageView = {
@@ -72,25 +71,46 @@ final class PosePracticeViewController: UIViewController {
     private let queue = DispatchQueue(label: "serial_queue")
     private var isRunning = false
     
+    private let viewModel: EducationViewModel
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(viewModel: EducationViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setUpOrientation()
+        viewModel.updateTimerType(vc: self)
+        setUpOrientation(as: .landscape)
         setUpConstraints()
         updateModel()
         configCameraCapture()
+        setTimer()
+        setUpAction()
     }
     
-    private func setUpOrientation() {
-        UIApplication.shared.isIdleTimerDisabled = true
-        
-        if let delegate = UIApplication.shared.delegate as? AppDelegate {
-            delegate.orientationLock = .landscapeRight
-        }
-        
-        navigationController?.setNavigationBarHidden(true, animated: true)
-        self.setNeedsUpdateOfSupportedInterfaceOrientations()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        cameraFeedManager?.startRunning()
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        cameraFeedManager?.stopRunning()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        imageViewFrame = overlayView.frame
+    }
+    
+    
     
     private func setUpConstraints() {
         let safeArea = view.safeAreaLayoutGuide
@@ -150,22 +170,7 @@ final class PosePracticeViewController: UIViewController {
             overlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        cameraFeedManager?.startRunning()
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        cameraFeedManager?.stopRunning()
-    }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        imageViewFrame = overlayView.frame
-    }
-    
+
     private func configCameraCapture() {
         cameraFeedManager = CameraFeedManager()
         cameraFeedManager.startRunning()
@@ -185,6 +190,43 @@ final class PosePracticeViewController: UIViewController {
                 os_log("Error: %@", log: .default, type: .error, String(describing: error))
             }
         }
+    }
+    
+    private func setTimer() {
+        let count = viewModel.timeLimit()
+        viewModel.timer
+            .autoconnect()
+            .scan(0) { counter, _ in counter + 1 }
+            .sink { [self] counter in
+                timeLabel.text = NumberAsTime(number: count - counter)
+                if counter == count {
+                    cameraFeedManager.stopRunning()
+                    // TEST
+                    Task {
+                        usleep(1000000)
+                        let vc = PosePracticeResultViewController(viewModel: viewModel)
+                        vc.modalPresentationStyle = .overFullScreen
+                        self.present(vc, animated: true)
+                    }
+                    viewModel.timer.connect().cancel()
+                }
+            }.store(in: &cancellables)
+    }
+    
+    private func NumberAsTime(number: Int) -> String {
+        let mValue = number/60
+        let sValue = number%60
+        
+        let minuteStr = mValue < 10 ? "0\(mValue)" : "\(mValue)"
+        let secondStr = sValue < 10 ? "0\(sValue)" : "\(sValue)"
+        return "\(minuteStr):\(secondStr)"
+    }
+    
+    private func setUpAction() {
+        quitButton.tapPublisher.sink { [weak self] in
+            self?.setUpOrientation(as: .portrait)
+            self?.dismiss(animated: true)
+        }.store(in: &cancellables)
     }
 }
 

--- a/CPR2U/CPR2U/Scene/Education/Pose/PracticeExplainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Pose/PracticeExplainViewController.swift
@@ -5,26 +5,55 @@
 //  Created by 황정현 on 2023/03/10.
 //
 
+import Combine
+import CombineCocoa
 import UIKit
 
 final class PracticeExplainViewController: UIViewController {
     
-    // temp: 추후 비디오가 삽입될 영역
+    // temp: 추후 설명용 이미지가 삽입될 영역
     private lazy var temp: UIView = {
         let view = UIView()
-        view.backgroundColor = .black
         return view
     }()
     
-    private let moveButton = UIButton()
+    private let moveButton: UIButton = {
+        let button = UIButton()
+        button.backgroundColor = .mainLightRed
+        button.setTitleColor(.mainBlack, for: .normal)
+        button.titleLabel?.font = UIFont(weight: .bold, size: 16)
+        button.setTitle("Moving on to Posture Practice", for: .normal)
+        return button
+    }()
+    
+    private let viewModel: EducationViewModel
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(viewModel: EducationViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         setUpConstraints()
         setUpStyle()
-        setUpText()
         setUpAction()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(true)
+        navigationController?.navigationBar.prefersLargeTitles = false
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(true)
+        navigationController?.navigationBar.prefersLargeTitles = true
     }
     
     private func setUpConstraints() {
@@ -46,7 +75,7 @@ final class PracticeExplainViewController: UIViewController {
         ])
         
         NSLayoutConstraint.activate([
-            moveButton.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            moveButton.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
             moveButton.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
             moveButton.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
             moveButton.heightAnchor.constraint(equalToConstant: 80)
@@ -54,18 +83,15 @@ final class PracticeExplainViewController: UIViewController {
     }
     
     private func setUpStyle() {
-        view.backgroundColor = .mainWhite
-        
-        moveButton.backgroundColor = .mainLightRed
-        moveButton.setTitleColor(.mainBlack, for: .normal)
-        moveButton.titleLabel?.font = UIFont(weight: .bold, size: 16)
-    }
-    
-    private func setUpText() {
-        moveButton.setTitle("Moving on to Posture Practice", for: .normal)
+        view.backgroundColor = .white
     }
     
     private func setUpAction() {
-        
+        moveButton.tapPublisher.sink { [self] in
+            setUpOrientation(as: .landscapeRight)
+            let vc = PosePracticeViewController(viewModel: viewModel)
+            vc.modalPresentationStyle = .overFullScreen
+            self.present(vc, animated: true)
+        }.store(in: &cancellables)
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Quiz/CustomNoticeView.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/CustomNoticeView.swift
@@ -12,11 +12,11 @@ protocol CustomNoticeViewDelegate: AnyObject {
 }
 
 enum NoticeUsage {
-    case quiz
+    case pf
     case certificate
 }
 
-final class CustomNoticeView: UIView {
+class CustomNoticeView: UIView {
     
     weak var delegate: CustomNoticeViewDelegate?
     
@@ -62,7 +62,7 @@ final class CustomNoticeView: UIView {
         return label
     }()
     
-    private let confirmButton: UIButton = {
+    let confirmButton: UIButton = {
         let button = UIButton()
         button.layer.cornerRadius = 22
         button.backgroundColor = .mainRed
@@ -73,7 +73,7 @@ final class CustomNoticeView: UIView {
     }()
     private let appearAnimDuration: CGFloat = 0.4
     
-    private var noticeType = NoticeUsage.quiz
+    private var noticeType = NoticeUsage.pf
 
     init(noticeAs: NoticeUsage) {
         super.init(frame: CGRect.zero)
@@ -157,8 +157,8 @@ final class CustomNoticeView: UIView {
         setSubTitle(subTitle: "You have got CPR Angel Certificate!")
     }
     
-    func setQuizResultNotice(isAllCorrect: Bool, quizResultString: String = ""){
-        if isAllCorrect {
+    func setPFResultNotice(isPass: Bool, quizResultString: String = ""){
+        if isPass {
             guard let image = UIImage(named: "success_heart.png") else { return }
             setImage(uiImage: image)
             setTitle(title: "Congratulation!")
@@ -183,8 +183,8 @@ final class CustomNoticeView: UIView {
         subTitleLabel.text = subTitle
     }
     
-    @objc private func didConfirmButtonTapped() {
-        if noticeType == .quiz {
+    @objc func didConfirmButtonTapped() {
+        if noticeType == .pf {
             delegate?.dismissQuizViewController()
         } else {
             noticeDisappear()
@@ -200,7 +200,7 @@ final class CustomNoticeView: UIView {
         })
     }
                        
-    private func noticeDisappear() {
+    func noticeDisappear() {
         UIView.animate(withDuration: appearAnimDuration/2, delay: 0, animations: {
             self.alpha = 0.0
         }, completion: { [weak self] _ in

--- a/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
@@ -266,6 +266,5 @@ extension EducationQuizViewController {
 extension EducationQuizViewController: CustomNoticeViewDelegate {
     func dismissQuizViewController() {
         delegate?.updateUserEducationStatus()
-        dismiss(animated: true)
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
@@ -8,8 +8,6 @@
 import UIKit
 import Combine
 
-
-
 final class EducationQuizViewController: UIViewController {
     
     private lazy var questionView = QuizQuestionView(questionNumber: 1, question: "When you find someone who has fallen, you have to compress his chest instantly.")
@@ -17,7 +15,7 @@ final class EducationQuizViewController: UIViewController {
     private lazy var oxChoiceView = OXQuizChoiceView(viewModel: viewModel)
     private lazy var multiChoiceView = MultiQuizChoiceView(viewModel: viewModel)
     
-    private lazy var noticeView = CustomNoticeView(noticeAs: .quiz)
+    private lazy var noticeView = CustomNoticeView(noticeAs: .pf)
     
     private lazy var answerLabel: UILabel =  {
         let label = UILabel()
@@ -206,11 +204,11 @@ extension EducationQuizViewController {
                 if isQuizAllCorrect {
                     Task {
                         try await self?.viewModel.saveQuizResult()
-                        self?.noticeView.setQuizResultNotice(isAllCorrect: true)
+                        self?.noticeView.setPFResultNotice(isPass: true)
                         self?.noticeView.noticeAppear()
                     }
                 } else {
-                    self?.noticeView.setQuizResultNotice(isAllCorrect: false, quizResultString: quizResultString)
+                    self?.noticeView.setPFResultNotice(isPass: false, quizResultString: quizResultString)
                     self?.noticeView.noticeAppear()
                 }
             }

--- a/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
@@ -197,8 +197,11 @@ extension EducationQuizViewController {
             
             if isQuizEnd {
                 if isQuizAllCorrect {
-                    self?.noticeView.setQuizResultNotice(isAllCorrect: true)
-                    self?.noticeView.noticeAppear()
+                    Task {
+                        try await self?.viewModel.saveQuizResult()
+                        self?.noticeView.setQuizResultNotice(isAllCorrect: true)
+                        self?.noticeView.noticeAppear()
+                    }
                 } else {
                     self?.noticeView.setQuizResultNotice(isAllCorrect: false, quizResultString: quizResultString)
                     self?.noticeView.noticeAppear()

--- a/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
@@ -189,6 +189,13 @@ extension EducationQuizViewController {
         
         output.quiz?.sink { quiz in
             self.updateQuiz(quiz: quiz)
+            
+            switch quiz.questionType {
+            case .ox:
+                self.oxChoiceView.interactionEnabled(to: true)
+            case .multi:
+                self.multiChoiceView.interactionEnabled(to: true)
+            }
         }.store(in: &cancellables)
         
         output.isQuizEnd.sink { [weak self] isQuizEnd in
@@ -260,6 +267,7 @@ extension EducationQuizViewController {
 // MARK: Delegate
 extension EducationQuizViewController: CustomNoticeViewDelegate {
     func dismissQuizViewController() {
+        delegate?.updateUserEducationStatus()
         dismiss(animated: true)
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Quiz/QuizChoiceView.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/QuizChoiceView.swift
@@ -75,6 +75,11 @@ public class QuizChoiceView: UIView {
         }
     }
     
+    func interactionEnabled(to status: Bool) {
+        choices.forEach({
+            $0.isUserInteractionEnabled = status
+        })
+    }
     func animateChoiceButton(answerIndex: Int) { }
     func resetChoiceButtonConstraint() { }
 }

--- a/CPR2U/CPR2U/Scene/Education/Quiz/QuizViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/QuizViewModel.swift
@@ -105,4 +105,9 @@ class QuizViewModel: OutputOnlyViewModelType {
             print(error)
         }
     }
+
+    func saveQuizResult() async throws{
+        (_, _) = try await eduManager.saveQuizResult(score: 100)
+    }
+    
 }

--- a/CPR2U/CPR2U/Scene/Education/TestViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/TestViewController.swift
@@ -7,45 +7,45 @@
 
 import UIKit
 
-class TestViewController: UIViewController {
-
-    private let educationManager = EducationManager(service: APIManager())
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        Task {
-            let result1 = try await educationManager.saveQuizResult(score: 100)
-            await print("RESULT 1 ", result1.0)
-            await print("RESULT 1 ", result1.1)
-            let result2 = try await educationManager.saveLectureProgress(lectureId: 1)
-            await print("RESULT 2 ", result2.0)
-            await print("RESULT 2 ", result2.1)
-            let result3 = try await educationManager.savePosturePracticeResult(score: 100)
-            await print("RESULT 3 ", result3.0)
-            await print("RESULT 3 ", result3.1)
-            let result4 = try await educationManager.getEducationProgress()
-            await print("RESULT 4 ", result4.0)
-            await print("RESULT 4 ", result4.1)
-            let result5 = try await educationManager.getQuizList()
-            await print("RESULT 5 ", result5.0)
-            await print("RESULT 5 ", result5.1)
-            let result6 = try await educationManager.getLecture()
-            await print("RESULT 6 ", result6.0)
-            await print("RESULT 6 ", result6.1)
-            let result7 = try await educationManager.getPostureLecture()
-            await print("RESULT 7 ", result7.1)
-        }
-    }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
-}
+//class TestViewController: UIViewController {
+//
+//    private let educationManager = EducationManager(service: APIManager())
+//    override func viewDidLoad() {
+//        super.viewDidLoad()
+//
+//        Task {
+//            let result1 = try await educationManager.saveQuizResult(score: 100)
+//            await print("RESULT 1 ", result1.0)
+//            await print("RESULT 1 ", result1.1)
+//            let result2 = try await educationManager.saveLectureProgress(lectureId: 1)
+//            await print("RESULT 2 ", result2.0)
+//            await print("RESULT 2 ", result2.1)
+//            let result3 = try await educationManager.savePosturePracticeResult(score: 100)
+//            await print("RESULT 3 ", result3.0)
+//            await print("RESULT 3 ", result3.1)
+//            let result4 = try await educationManager.getEducationProgress()
+//            await print("RESULT 4 ", result4.0)
+//            await print("RESULT 4 ", result4.1)
+//            let result5 = try await educationManager.getQuizList()
+//            await print("RESULT 5 ", result5.0)
+//            await print("RESULT 5 ", result5.1)
+//            let result6 = try await educationManager.getLecture()
+//            await print("RESULT 6 ", result6.0)
+//            await print("RESULT 6 ", result6.1)
+//            let result7 = try await educationManager.getPostureLecture()
+//            await print("RESULT 7 ", result7.1)
+//        }
+//    }
+//    
+//
+//    /*
+//    // MARK: - Navigation
+//
+//    // In a storyboard-based application, you will often want to do a little preparation before navigation
+//    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+//        // Get the new view controller using segue.destination.
+//        // Pass the selected object to the new view controller.
+//    }
+//    */
+//
+//}

--- a/CPR2U/CPR2U/Scene/Education/TestViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/TestViewController.swift
@@ -14,7 +14,7 @@ class TestViewController: UIViewController {
         super.viewDidLoad()
 
         Task {
-            let result1 = try await educationManager.saveQuizResult()
+            let result1 = try await educationManager.saveQuizResult(score: 100)
             await print("RESULT 1 ", result1.0)
             await print("RESULT 1 ", result1.1)
             let result2 = try await educationManager.saveLectureProgress(lectureId: 1)

--- a/CPR2U/CPR2U/Scene/Education/TestViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/TestViewController.swift
@@ -1,0 +1,51 @@
+//
+//  TestViewController.swift
+//  CPR2U
+//
+//  Created by 황정현 on 2023/03/22.
+//
+
+import UIKit
+
+class TestViewController: UIViewController {
+
+    private let educationManager = EducationManager(service: APIManager())
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        Task {
+            let result1 = try await educationManager.saveQuizResult()
+            await print("RESULT 1 ", result1.0)
+            await print("RESULT 1 ", result1.1)
+            let result2 = try await educationManager.saveLectureProgress(lectureId: 1)
+            await print("RESULT 2 ", result2.0)
+            await print("RESULT 2 ", result2.1)
+            let result3 = try await educationManager.savePosturePracticeResult(score: 100)
+            await print("RESULT 3 ", result3.0)
+            await print("RESULT 3 ", result3.1)
+            let result4 = try await educationManager.getEducationProgress()
+            await print("RESULT 4 ", result4.0)
+            await print("RESULT 4 ", result4.1)
+            let result5 = try await educationManager.getQuizList()
+            await print("RESULT 5 ", result5.0)
+            await print("RESULT 5 ", result5.1)
+            let result6 = try await educationManager.getLecture()
+            await print("RESULT 6 ", result6.0)
+            await print("RESULT 6 ", result6.1)
+            let result7 = try await educationManager.getPostureLecture()
+            await print("RESULT 7 ", result7.1)
+        }
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/CPR2U/CPR2U/Scene/Main/TabBarViewController.swift
+++ b/CPR2U/CPR2U/Scene/Main/TabBarViewController.swift
@@ -9,6 +9,15 @@ import UIKit
 
 final class TabBarViewController: UITabBarController {
 
+    init(_ selectedIndex: Int = 1) {
+        super.init(nibName: nil, bundle: nil)
+        self.selectedIndex = selectedIndex
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -40,7 +49,5 @@ final class TabBarViewController: UITabBarController {
         navigationMypage.navigationBar.prefersLargeTitles = true
         
         setViewControllers([navigationEdu, navigationCall, navigationMypage], animated: false)
-        
-        selectedIndex = 1
     }
 }

--- a/CPR2U/CPR2U/Scene/Splash/AutoLoginViewController.swift
+++ b/CPR2U/CPR2U/Scene/Splash/AutoLoginViewController.swift
@@ -46,7 +46,8 @@ final class AutoLoginViewController: UIViewController {
                 let result = try await viewModel.autoLogin()
                 usleep(1200000)
                 if result == true {
-                    let vc = TabBarViewController()
+//                    let vc = TabBarViewController()
+                    let vc = TestViewController()
                     guard let window = self.view.window else { return }
                     await window.setRootViewController(vc, animated: true)
                 } else {

--- a/CPR2U/CPR2U/Scene/Splash/AutoLoginViewController.swift
+++ b/CPR2U/CPR2U/Scene/Splash/AutoLoginViewController.swift
@@ -46,8 +46,8 @@ final class AutoLoginViewController: UIViewController {
                 let result = try await viewModel.autoLogin()
                 usleep(1200000)
                 if result == true {
-//                    let vc = TabBarViewController()
-                    let vc = TestViewController()
+                    let vc = TabBarViewController()
+//                    let vc = TestViewController()
                     guard let window = self.view.window else { return }
                     await window.setRootViewController(vc, animated: true)
                 } else {

--- a/CPR2U/CPR2U/Service/Network/Auth/AuthEndPoint.swift
+++ b/CPR2U/CPR2U/Service/Network/Auth/AuthEndPoint.swift
@@ -1,5 +1,5 @@
 //
-//  SignEndPoint.swift
+//  AuthEndPoint.swift
 //  CPR2U
 //
 //  Created by 황정현 on 2023/03/11.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum SignEndPoint {
+enum AuthEndPoint {
     case phoneNumberVerify (phoneNumber: String)
     case nicknameVerify (nickname: String)
     case signIn (phoneNumber: String, deviceToken: String)
@@ -15,7 +15,7 @@ enum SignEndPoint {
     case autoLogin (refreshToken: String)
 }
 
-extension SignEndPoint: EndPoint {
+extension AuthEndPoint: EndPoint {
     
     var method: HttpMethod {
         switch self {

--- a/CPR2U/CPR2U/Service/Network/Auth/AuthManager.swift
+++ b/CPR2U/CPR2U/Service/Network/Auth/AuthManager.swift
@@ -24,35 +24,35 @@ struct AuthManager: AuthService {
     }
     
     func phoneNumberVerify(phoneNumber: String) async throws -> (success: Bool, data: SMSCodeResult?) {
-        let request = SignEndPoint
+        let request = AuthEndPoint
             .phoneNumberVerify(phoneNumber: phoneNumber)
             .createRequest()
         return try await self.service.request(request)
     }
     
     func nicknameVerify(nickname: String) async throws -> (success: Bool, data: NicknameVerifyResult?) {
-        let request = SignEndPoint
+        let request = AuthEndPoint
             .nicknameVerify(nickname: nickname)
             .createRequest()
         return try await self.service.request(request)
         }
     
     func signIn(phoneNumber: String, deviceToken: String) async throws -> (success: Bool, data: SignInResult?) {
-        let request = SignEndPoint
+        let request = AuthEndPoint
             .signIn(phoneNumber: phoneNumber, deviceToken: deviceToken)
             .createRequest()
         return try await self.service.request(request)
     }
     
     func signUp(nickname: String, phoneNumber: String, deviceToken: String) async throws -> (success: Bool, data: SignUpResult?) {
-        let request = SignEndPoint
+        let request = AuthEndPoint
             .signUp(nickname: nickname, phoneNumber: phoneNumber, deviceToken: deviceToken)
             .createRequest()
         return try await self.service.request(request)
     }
     
     func autoLogin(refreshToken: String) async throws -> (success: Bool, data: AutoLoginResult?) {
-        let request = SignEndPoint
+        let request = AuthEndPoint
             .autoLogin(refreshToken: refreshToken)
             .createRequest()
         return try await self.service.request(request)

--- a/CPR2U/CPR2U/Service/Network/Education/EducationEndPoint.swift
+++ b/CPR2U/CPR2U/Service/Network/Education/EducationEndPoint.swift
@@ -1,0 +1,103 @@
+//
+//  EducationEndPoint.swift
+//  CPR2U
+//
+//  Created by 황정현 on 2023/03/22.
+//
+
+import Foundation
+
+enum EducationEndPoint {
+    case saveQuizResult
+    case saveLectureProgress(lectureId: Int)
+    case savePosturePracticeResult(score: Int)
+    case getEducationProgress
+    case getQuizList
+    case getLecture
+    case getPostureLecture
+}
+
+extension EducationEndPoint: EndPoint {
+    
+    var method: HttpMethod {
+        switch self {
+        case .saveQuizResult, .saveLectureProgress, .savePosturePracticeResult:
+            return .POST
+        case .getEducationProgress, .getQuizList, .getLecture, .getPostureLecture:
+            return .GET
+        }
+    }
+    
+    var body: Data? {
+        var params: [String : Int]
+        switch self {
+        case .savePosturePracticeResult(let score):
+            params = ["score" : score]
+        case .saveQuizResult, .saveLectureProgress, .getEducationProgress, .getQuizList, .getLecture, .getPostureLecture:
+            params = [:]
+        }
+        
+        return params.encode()
+    }
+    
+    func getURL(path: String) -> String {
+        let baseURL = URLs.baseURL
+        switch self {
+        case .saveQuizResult:
+            return "\(baseURL)/education/quizzes/progress"
+        case .saveLectureProgress(let lectureId): // ????
+            return "\(baseURL)/education/lectures/progress/\(lectureId)"
+        case .savePosturePracticeResult:
+            return "\(baseURL)/education/exercises/progress"
+        case .getEducationProgress:
+            return "\(baseURL)/education"
+        case .getQuizList:
+            return "\(baseURL)/education/quizzes"
+        case .getLecture:
+            return "\(baseURL)/education/lectures"
+        case .getPostureLecture:
+            return "\(baseURL)/education/exercises"
+        }
+    }
+    
+    func createRequest() -> NetworkRequest {
+        let baseURL = URLs.baseURL
+        var headers: [String: String] = [:]
+        headers["Authorization"] = UserDefaultsManager.accessToken
+
+        switch self {
+        case .saveQuizResult:
+            headers["Content-Type"] = "application/json"
+            return NetworkRequest(url: getURL(path: baseURL),
+                                  httpMethod: method,
+                                  headers: headers,
+                                  requestBody: body)
+        case .saveLectureProgress:
+            return NetworkRequest(url: getURL(path: baseURL),
+                                  httpMethod: method,
+                                  headers: headers)
+        case .savePosturePracticeResult:
+            headers["Content-Type"] = "application/json"
+            return NetworkRequest(url: getURL(path: baseURL),
+                                  httpMethod: method,
+                                  headers: headers,
+                                  requestBody: body)
+        case .getEducationProgress:
+            return NetworkRequest(url: getURL(path: baseURL),
+                                  httpMethod: method,
+                                  headers: headers)
+        case .getQuizList:
+            return NetworkRequest(url: getURL(path: baseURL),
+                                  httpMethod: method,
+                                  headers: headers)
+        case .getLecture:
+            return NetworkRequest(url: getURL(path: baseURL),
+                                  httpMethod: method,
+                                  headers: headers)
+        case .getPostureLecture:
+            return NetworkRequest(url: getURL(path: baseURL),
+                                  httpMethod: method,
+                                  headers: headers)
+        }
+    }
+}

--- a/CPR2U/CPR2U/Service/Network/Education/EducationEndPoint.swift
+++ b/CPR2U/CPR2U/Service/Network/Education/EducationEndPoint.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum EducationEndPoint {
-    case saveQuizResult
+    case saveQuizResult(score: Int)
     case saveLectureProgress(lectureId: Int)
     case savePosturePracticeResult(score: Int)
     case getEducationProgress
@@ -31,9 +31,9 @@ extension EducationEndPoint: EndPoint {
     var body: Data? {
         var params: [String : Int]
         switch self {
-        case .savePosturePracticeResult(let score):
+        case .saveQuizResult(let score), .savePosturePracticeResult(let score):
             params = ["score" : score]
-        case .saveQuizResult, .saveLectureProgress, .getEducationProgress, .getQuizList, .getLecture, .getPostureLecture:
+        case .saveLectureProgress, .getEducationProgress, .getQuizList, .getLecture, .getPostureLecture:
             params = [:]
         }
         

--- a/CPR2U/CPR2U/Service/Network/Education/EducationManager.swift
+++ b/CPR2U/CPR2U/Service/Network/Education/EducationManager.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 protocol EducationService {
-    func saveQuizResult() async throws -> (Bool, QuizResult?)
-    func saveLectureProgress(lectureId: Int) async throws -> (Bool, LectureProgressResult?)
-    func savePosturePracticeResult(score: Int) async throws -> (Bool, PosturePracticeResult?)
-    func getEducationProgress() async throws -> (Bool, UserInfo?)
-    func getQuizList() async throws -> (Bool, [QuizInfo]?)
-    func getLecture() async throws -> (Bool, LectureProgressInfo?)
-    func getPostureLecture() async throws -> (Bool, PostureLectureInfo?)
+    func saveQuizResult(score: Int) async throws -> (success: Bool, data: QuizResult?)
+    func saveLectureProgress(lectureId: Int) async throws -> (success: Bool, data: LectureProgressResult?)
+    func savePosturePracticeResult(score: Int) async throws -> (success: Bool, data: PosturePracticeResult?)
+    func getEducationProgress() async throws -> (success: Bool, data: UserInfo?)
+    func getQuizList() async throws -> (success: Bool, data: [QuizInfo]?)
+    func getLecture() async throws -> (success: Bool, data: LectureProgressInfo?)
+    func getPostureLecture() async throws -> (success: Bool, data: PostureLectureInfo?)
 }
 
 struct EducationManager: EducationService {
@@ -25,49 +25,49 @@ struct EducationManager: EducationService {
         self.service = service
     }
     
-    func saveQuizResult() async throws -> (Bool, QuizResult?) {
+    func saveQuizResult(score: Int) async throws -> (success: Bool, data: QuizResult?) {
         let request = EducationEndPoint
-            .saveQuizResult
+            .saveQuizResult(score: score)
             .createRequest()
         return try await self.service.request(request)
     }
     
-    func saveLectureProgress(lectureId: Int) async throws -> (Bool, LectureProgressResult?) {
+    func saveLectureProgress(lectureId: Int) async throws -> (success: Bool, data: LectureProgressResult?) {
         let request = EducationEndPoint
             .saveLectureProgress(lectureId: lectureId)
             .createRequest()
         return try await self.service.request(request)
     }
     
-    func savePosturePracticeResult(score: Int) async throws -> (Bool, PosturePracticeResult?) {
+    func savePosturePracticeResult(score: Int) async throws -> (success: Bool, data: PosturePracticeResult?) {
         let request = EducationEndPoint
             .savePosturePracticeResult(score: score)
             .createRequest()
         return try await self.service.request(request)
     }
     
-    func getEducationProgress() async throws -> (Bool, UserInfo?) {
+    func getEducationProgress() async throws -> (success: Bool, data: UserInfo?) {
         let request = EducationEndPoint
             .getEducationProgress
             .createRequest()
         return try await self.service.request(request)
     }
     
-    func getQuizList() async throws -> (Bool, [QuizInfo]?) {
+    func getQuizList() async throws -> (success: Bool, data: [QuizInfo]?) {
         let request = EducationEndPoint
             .getQuizList
             .createRequest()
         return try await self.service.request(request)
     }
     
-    func getLecture() async throws -> (Bool, LectureProgressInfo?) {
+    func getLecture() async throws -> (success: Bool, data: LectureProgressInfo?) {
         let request = EducationEndPoint
             .getLecture
             .createRequest()
         return try await self.service.request(request)
     }
     
-    func getPostureLecture() async throws -> (Bool, PostureLectureInfo?) {
+    func getPostureLecture() async throws -> (success: Bool, data: PostureLectureInfo?) {
         let request = EducationEndPoint
             .getPostureLecture
             .createRequest()

--- a/CPR2U/CPR2U/Service/Network/Education/EducationManager.swift
+++ b/CPR2U/CPR2U/Service/Network/Education/EducationManager.swift
@@ -1,0 +1,76 @@
+//
+//  EducationManager.swift
+//  CPR2U
+//
+//  Created by 황정현 on 2023/03/22.
+//
+
+import Foundation
+
+protocol EducationService {
+    func saveQuizResult() async throws -> (Bool, QuizResult?)
+    func saveLectureProgress(lectureId: Int) async throws -> (Bool, LectureProgressResult?)
+    func savePosturePracticeResult(score: Int) async throws -> (Bool, PosturePracticeResult?)
+    func getEducationProgress() async throws -> (Bool, UserInfo?)
+    func getQuizList() async throws -> (Bool, [QuizInfo]?)
+    func getLecture() async throws -> (Bool, LectureProgressInfo?)
+    func getPostureLecture() async throws -> (Bool, PostureLectureInfo?)
+}
+
+struct EducationManager: EducationService {
+    
+    private let service: Requestable
+    
+    init(service: Requestable) {
+        self.service = service
+    }
+    
+    func saveQuizResult() async throws -> (Bool, QuizResult?) {
+        let request = EducationEndPoint
+            .saveQuizResult
+            .createRequest()
+        return try await self.service.request(request)
+    }
+    
+    func saveLectureProgress(lectureId: Int) async throws -> (Bool, LectureProgressResult?) {
+        let request = EducationEndPoint
+            .saveLectureProgress(lectureId: lectureId)
+            .createRequest()
+        return try await self.service.request(request)
+    }
+    
+    func savePosturePracticeResult(score: Int) async throws -> (Bool, PosturePracticeResult?) {
+        let request = EducationEndPoint
+            .savePosturePracticeResult(score: score)
+            .createRequest()
+        return try await self.service.request(request)
+    }
+    
+    func getEducationProgress() async throws -> (Bool, UserInfo?) {
+        let request = EducationEndPoint
+            .getEducationProgress
+            .createRequest()
+        return try await self.service.request(request)
+    }
+    
+    func getQuizList() async throws -> (Bool, [QuizInfo]?) {
+        let request = EducationEndPoint
+            .getQuizList
+            .createRequest()
+        return try await self.service.request(request)
+    }
+    
+    func getLecture() async throws -> (Bool, LectureProgressInfo?) {
+        let request = EducationEndPoint
+            .getLecture
+            .createRequest()
+        return try await self.service.request(request)
+    }
+    
+    func getPostureLecture() async throws -> (Bool, PostureLectureInfo?) {
+        let request = EducationEndPoint
+            .getPostureLecture
+            .createRequest()
+        return try await self.service.request(request)
+    }
+}

--- a/CPR2U/CPR2U/Util/Constants/URLs.swift
+++ b/CPR2U/CPR2U/Util/Constants/URLs.swift
@@ -9,15 +9,15 @@ import Foundation
 
 class URLs {
 //     FOR CI:CD
-    static var baseURL: String = {
-        return ""
-    }()
+//    static var baseURL: String = {
+//        return ""
+//    }()
 
     // REAL BaseURL
-//    static var baseURL: String = {
-//        guard let privatePlist = Bundle.main.url(forResource: "Private", withExtension: "plist"), let dictionary = NSDictionary(contentsOf: privatePlist), let link: String = dictionary["baseURL"] as? String else { return "" }
-//
-//        return link
-//    }()
+    static var baseURL: String = {
+        guard let privatePlist = Bundle.main.url(forResource: "Private", withExtension: "plist"), let dictionary = NSDictionary(contentsOf: privatePlist), let link: String = dictionary["baseURL"] as? String else { return "" }
+
+        return link
+    }()
 
 }

--- a/CPR2U/CPR2U/Util/Extension/UIViewController+.swift
+++ b/CPR2U/CPR2U/Util/Extension/UIViewController+.swift
@@ -7,8 +7,8 @@
 
 import UIKit
 
-// https://stackoverflow.com/questions/24126678/close-ios-keyboard-by-touching-anywhere-using-swift
 extension UIViewController {
+    // https://stackoverflow.com/questions/24126678/close-ios-keyboard-by-touching-anywhere-using-swift
     func hideKeyboardWhenTappedAround() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
         view.addGestureRecognizer(tap)
@@ -16,5 +16,14 @@ extension UIViewController {
     
     @objc func dismissKeyboard() {
         view.endEditing(true)
+    }
+    
+    func setUpOrientation(as status: UIInterfaceOrientationMask) {
+        UIApplication.shared.isIdleTimerDisabled = true
+        
+        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+            delegate.orientationLock = status
+        }
+        self.setNeedsUpdateOfSupportedInterfaceOrientations()
     }
 }

--- a/CPR2U/CPR2U/Util/Protocol/ViewModelProtocol.swift
+++ b/CPR2U/CPR2U/Util/Protocol/ViewModelProtocol.swift
@@ -18,5 +18,5 @@ protocol DefaultViewModelType {
 protocol OutputOnlyViewModelType {
     associatedtype Output
 
-    func transform() -> Output
+//    func transform() -> Output
 }

--- a/CPR2U/CPR2U/Util/Wrapper/UserDefaultsManager.swift
+++ b/CPR2U/CPR2U/Util/Wrapper/UserDefaultsManager.swift
@@ -33,4 +33,7 @@ struct UserDefaultsManager {
     
     @UserDefaultWrapper(key: "refreshToken", defaultValue: "")
     static var refreshToken
+    
+    @UserDefaultWrapper(key: "isCertificateNotice", defaultValue: false)
+    static var isCertificateNotice
 }


### PR DESCRIPTION
### One line Description
- 교육 파트에서 발생하는 서버 - 클라이언트 간의 데이터 전송 관련 코드 작성

### Work Detail(Optional)
|VC|Description|
|:---:|:---|
|**1. 강의 수강 페이지**|타이머 제한 시간 경과 후 API 호출|
|**2. 퀴즈 페이지**|퀴즈를 전부 맞췄을 때에만 API 호출|
|**3. 자세 연습 페이지**|강의 수강 페이지와 동일하게 제한 시간 경과 후 API 호출.|
|**3. 자세 연습 완료 후**|자세 연습까지 완료하여 Certificate를 얻은 경우, 얻은 직후 1회성으로 Alert를 띄운다|
|**4. 수료 후**|1회성으로 Alert를 띄운 다음에는 더 이상 Alert는 표시되지 않는다.|

|1. 강의 수강|2-a. 퀴즈 - 실패 시|2-b. 퀴즈 - 성공 시|3. 자세 연습|4. 수료 후 앱 재시작 시|
|:---:|:---:|:---:|:---:|:---:|
|![](https://user-images.githubusercontent.com/96641477/227714130-6500136e-0711-41a8-b4e1-caeea5324c2a.mp4)|![](https://user-images.githubusercontent.com/96641477/227714132-fd873b25-512f-4ce1-864d-d09e40ceb24e.mp4)|![](https://user-images.githubusercontent.com/96641477/227714133-0c67e8fd-7ac3-4997-85f4-8c927111b017.mp4)|![](https://user-images.githubusercontent.com/96641477/227714134-6e97a47a-e658-4487-8a67-ab0300765687.mp4)|![](https://user-images.githubusercontent.com/96641477/227714135-ffcec831-c00e-4747-a577-4bc246d15d9d.mp4)|

### 비고
_`GCD`와 `Concurrency`와 `Combine`과 `Delegate`의 혼돈의 카오스..._
**추후 강력! 강력하게!!! 리팩토링할 예정입니다.**

- 현재 자세 연습에 대한 결과를 저장할 때 임의로 `90`이 저장되고 있습니다. 추후 #28 구현 시 수정할 예정입니다.
- 뷰 간의 Orientation 변경 시 자연스럽게 전환되지 않는 이슈에 대해서 추후 리팩토링 예정입니다.

### Issue
- #32 
- #36 
- #37
- Close #32 
- Close #36 
- Close #37