### PR TITLE
[FEAT] #51 교육 자세 연습 파트 로직 추가

### DIFF
--- a/CPR2U/CPR2U/Scene/Education/EducationViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Education/EducationViewModel.swift
@@ -102,10 +102,10 @@ enum PressDepthStatus: String {
     case wrong = "Wrong"
     
     // 압박 깊이
-    // 45 이상    : 15
-    // 30 - 45   : 33
-    // 15 - 30   : 15
-    // 0  - 15.  : 5
+    // 30 이상    : 15
+    // 18 - 30   : 33
+    // 5 - 18   : 15
+    // 0  - 5.  : 5
     var score: Int {
         switch self {
         case .deep:
@@ -137,6 +137,7 @@ enum PressDepthStatus: String {
         }
     }
 }
+
 enum AngelStatus: Int {
     case acquired
     case expired

--- a/CPR2U/CPR2U/Scene/Education/EducationViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Education/EducationViewModel.swift
@@ -14,12 +14,12 @@ enum CompressionRateStatus: String {
     case adequate = "Adequate"
     case fast = "Fast"
     case tooFast = "Too Fast"
-    case wrong
+    case wrong = "Wrong"
     
     // 압박 속도
-    // 190-250 : 50점
-    // 170-270 : 35점
-    // 150-290 : 20점
+    // 190-250 : 33점
+    // 170-270 : 22점
+    // 150-290 : 11점
     var score: Int {
         switch self {
         case .adequate:
@@ -59,9 +59,9 @@ enum AngleStatus: String {
     
     // 팔 각도
     // CORRECT : NON-CORRECT
-    // 7:3     : 50점
-    // 6:4     : 35점
-    // 5:5     : 20점
+    // 7:3     : 33점
+    // 6:4     : 22점
+    // 5:5     : 11점
     // 나머지    : 5점
     var score: Int {
         switch self {
@@ -79,7 +79,7 @@ enum AngleStatus: String {
     var description: String {
         switch self {
         case .adequate:
-            return "Good job! Very Nice Angle!"
+            return "Good job! Very Nice angle!"
         case .almost:
             return "Almost there. Try again"
         case .notGood:
@@ -90,6 +90,53 @@ enum AngleStatus: String {
     }
 }
 
+// 45... : 15
+// 30...45 : 33
+// 15...30 : 15
+// 0...15 : 5
+enum PressDepthStatus: String {
+    case deep = "Deep"
+    case adequate = "Adequate"
+    case shallow = "Slightly Shallow"
+    case tooShallow = "Too Shallow"
+    case wrong = "Wrong"
+    
+    // 압박 깊이
+    // 45 이상    : 15
+    // 30 - 45   : 33
+    // 15 - 30   : 15
+    // 0  - 15.  : 5
+    var score: Int {
+        switch self {
+        case .deep:
+            return 15
+        case .adequate:
+            return 33
+        case .shallow:
+            return 15
+        case .tooShallow:
+            return 5
+        case .wrong:
+            return 0
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .deep:
+            return "Press slight"
+        case .adequate:
+            return "Good job! Very adequate!"
+        case .shallow:
+            return "Press little deeper"
+        case .tooShallow:
+            return "It's too shallow. Press deeply"
+        case .wrong:
+            return "Something went wrong. Try Again"
+            
+        }
+    }
+}
 enum AngelStatus: Int {
     case acquired
     case expired
@@ -118,7 +165,7 @@ enum AngelStatus: Int {
 
 enum TimerType: Int {
     case lecture = 5 //3001
-    case posture = 130
+    case posture = 10 // 130
     case other = 0
 }
 
@@ -136,6 +183,7 @@ final class EducationViewModel: AsyncOutputOnlyViewModelType {
     
     private var compressionRate: Int?
     private var angleRate: (correct: Int?, nonCorrect: Int?)
+    private var pressDepthRate: CGFloat?
     
     init() {
         eduManager = EducationManager(service: APIManager())
@@ -306,8 +354,9 @@ final class EducationViewModel: AsyncOutputOnlyViewModelType {
         }
     }
     
-    func judgePostureResult() -> (compResult: CompressionRateStatus, angleResult: AngleStatus){
-        guard let compRate = compressionRate else { return (CompressionRateStatus.wrong, AngleStatus.bad) }
+    func judgePostureResult() -> (compResult: CompressionRateStatus, angleResult: AngleStatus, pressDepth: PressDepthStatus) {
+        guard let compRate = compressionRate, let correct = angleRate.correct, let nonCorrect = angleRate.nonCorrect, let pressRate = pressDepthRate else { return (CompressionRateStatus.wrong, AngleStatus.bad, PressDepthStatus.shallow) }
+        
         var compResult: CompressionRateStatus = .adequate
         switch compRate {
         case ...170:
@@ -325,7 +374,7 @@ final class EducationViewModel: AsyncOutputOnlyViewModelType {
         }
         
         let angleRate = angleRate
-        guard let correct = angleRate.correct, let nonCorrect = angleRate.nonCorrect else { return (CompressionRateStatus.wrong, AngleStatus.bad) }
+        
         var angleResult: AngleStatus = .adequate
         let totalAngleCount = Double(correct + nonCorrect)
                 
@@ -341,16 +390,33 @@ final class EducationViewModel: AsyncOutputOnlyViewModelType {
         }
         
         print(totalAngleCount)
-        if totalAngleCount < 100 {
+        if totalAngleCount < 1000 {
             angleResult = .bad
         }
-        return (compResult, angleResult)
+        
+        var pressDepthResult: PressDepthStatus = .wrong
+        
+        switch pressRate {
+        case 30.0... :
+            pressDepthResult = .deep
+        case 18.0..<30.0:
+            pressDepthResult = .adequate
+        case 5.0..<18.0:
+            pressDepthResult = .shallow
+        case 0.0..<5.0:
+            pressDepthResult = .tooShallow
+        default:
+            pressDepthResult = .wrong
+        }
+        
+        return (compResult, angleResult, pressDepthResult)
     }
     
-    func setPostureResult(compCount: Int, armAngleCount: (correct: Int, nonCorrect: Int)) {
+    func setPostureResult(compCount: Int, armAngleCount: (correct: Int, nonCorrect: Int), pressDepth: CGFloat) {
         compressionRate = compCount
         angleRate.correct = armAngleCount.correct
         angleRate.nonCorrect = armAngleCount.nonCorrect
+        pressDepthRate = pressDepth
         
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Pose/CameraOverlayView.swift
+++ b/CPR2U/CPR2U/Scene/Education/Pose/CameraOverlayView.swift
@@ -87,6 +87,7 @@ class CameraOverlayView: UIImageView {
       
     image.draw(at: .zero)
     context.setLineWidth(Config.dot.radius)
+    drawDots(at: context, dots: strokes.dots)
     context.setStrokeColor(UIColor.blue.cgColor)
     context.strokePath()
       guard let newImage = UIGraphicsGetImageFromCurrentImageContext() else { fatalError() }
@@ -172,7 +173,7 @@ class CameraOverlayView: UIImageView {
         })
         
         // 일직선 판별
-        var isCorrect = xShoulder - xElbow < 20 && xElbow - xWrist < 20
+        var isCorrect = xShoulder - xElbow < 10 && xElbow - xWrist < 10
         if (isCorrect) {
             correct += 1
         } else {
@@ -190,7 +191,11 @@ class CameraOverlayView: UIImageView {
             minHeight = yWrist
             
             // wristList에 ${손목의 최대 높이 - 손목의 최소 높이}를 저장
-            wristList.append(maxHeight - minHeight)
+            
+            let num = maxHeight > minHeight ? maxHeight - minHeight : minHeight - maxHeight
+            wristList.append(num)
+            print(wristList.last)
+            
             // wristList에 저장된 깊이 값으로 CPR 깊이가 적절한지 확인한다.
             // wristList에 저장된 값의 개수로 CPR 속도(2분 동안 CPR한 횟수)가 적절한지 확인한다.
             //  가슴압박 속도는 분당 100~120회, 깊이는 5~6㎝로 빠르고 깊게 30회 압박
@@ -206,6 +211,12 @@ class CameraOverlayView: UIImageView {
     
     func getArmAngleRate() -> (correct: Int, nonCorrect: Int) {
         return (correct, nonCorrect)
+    }
+    
+    func getAveragePressDepth() -> CGFloat {
+        let total = wristList.reduce(0){$0 + $1}
+        let len = CGFloat(wristList.count)
+        return total/len
     }
     
 }

--- a/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeResultViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeResultViewController.swift
@@ -159,8 +159,9 @@ final class PosePracticeResultViewController: UIViewController {
         compressRateResultView.setDescriptionLabelText(as: result.compResult.description)
         armAngleResultView.setResultLabelText(as: result.angleResult.rawValue)
         armAngleResultView.setDescriptionLabelText(as: result.angleResult.description)
-        
-        let score = result.compResult.score + result.angleResult.score
+        pressDepthResultView.setResultLabelText(as: result.pressDepth.rawValue)
+        pressDepthResultView.setDescriptionLabelText(as: result.pressDepth.description)
+        let score = result.compResult.score + result.angleResult.score + result.pressDepth.score + 1
         finalResultView.setUpScore(score: score)
     }
 }

--- a/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Pose/PosePracticeViewController.swift
@@ -209,11 +209,14 @@ final class PosePracticeViewController: UIViewController {
             .sink { [self] counter in
                 if counter > 5 {
                     timeLabel.text = (count - counter - 5).numberAsTime()
-                    if counter == 125 {
+                    if counter == 20 {
+                        
                         cameraFeedManager.stopRunning()
+                        print("COMPRESS RATE", overlayView.getCompressionTotalCount())
                         print("Correct \(overlayView.correct)")
                         print("NON-Correct \(overlayView.nonCorrect)")
-                        viewModel.setPostureResult(compCount: overlayView.getCompressionTotalCount(), armAngleCount: overlayView.getArmAngleRate())
+                        print("PRESS DEPTH", overlayView.getAveragePressDepth())
+                        viewModel.setPostureResult(compCount: overlayView.getCompressionTotalCount(), armAngleCount: overlayView.getArmAngleRate(), pressDepth: overlayView.getAveragePressDepth())
                         Task {
                             usleep(1000000)
                             let vc = PosePracticeResultViewController(viewModel: viewModel)


### PR DESCRIPTION
### One line Description
압박 깊이 측정 코드 구현

### Work Detail(Optional)
압박 깊이 측정 코드부로 대체합니다.

**압박 깊이 측정 enum 코드부**
```swift
// EducationViewModel.swift
enum PressDepthStatus: String {
    case deep = "Deep"
    case adequate = "Adequate"
    case shallow = "Slightly Shallow"
    case tooShallow = "Too Shallow"
    case wrong = "Wrong"
    
    // 압박 깊이
    // 30 이상    : 15
    // 18 - 30   : 33
    // 5 - 18   : 15
    // 0  - 5.  : 5
    var score: Int {
        switch self {
        case .deep:
            return 15
        case .adequate:
            return 33
        case .shallow:
            return 15
        case .tooShallow:
            return 5
        case .wrong:
            return 0
        }
    }
    
    var description: String {
        switch self {
        case .deep:
            return "Press slight"
        case .adequate:
            return "Good job! Very adequate!"
        case .shallow:
            return "Press little deeper"
        case .tooShallow:
            return "It's too shallow. Press deeply"
        case .wrong:
            return "Something went wrong. Try Again"
            
        }
    }
}
```

**판별문**
```swift
 var pressDepthResult: PressDepthStatus = .wrong
        
        switch pressRate {
        case 30.0... :
            pressDepthResult = .deep
        case 18.0..<30.0:
            pressDepthResult = .adequate
        case 5.0..<18.0:
            pressDepthResult = .shallow
        case 0.0..<5.0:
            pressDepthResult = .tooShallow
        default:
            pressDepthResult = .wrong
        }
```

### Issue
- #51
- Close #51