### PR TITLE
[FEAT] #57 출동 현황 실시간 반영 API 추가

### DIFF
--- a/CPR2U/CPR2U/Data/DTO/Call.swift
+++ b/CPR2U/CPR2U/Data/DTO/Call.swift
@@ -26,3 +26,7 @@ struct CallResult: Codable {
 }
 
 struct CallEndResult:Codable { }
+
+struct DispatcherCountResult: Codable {
+    let number_of_angels: Int
+}

--- a/CPR2U/CPR2U/Scene/Call/CallViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Call/CallViewModel.swift
@@ -95,6 +95,17 @@ final class CallViewModel: OutputOnlyViewModelType {
         }
     }
     
+    func countDispatcher() async throws -> Int? {
+        guard let callId = callId else { return nil }
+        
+        let result = Task { () -> Int? in
+            let callResult = try await callManager.countDispatcher(callId: callId)
+            return callResult.data?.number_of_angels
+        }
+        
+        return try await result.value
+    }
+    
     private func updateCallId(callId: Int) {
         self.callId = callId
     }

--- a/CPR2U/CPR2U/Scene/Call/DispatchWait/ApproachNoticeView.swift
+++ b/CPR2U/CPR2U/Scene/Call/DispatchWait/ApproachNoticeView.swift
@@ -192,6 +192,14 @@ final class ApproachNoticeView: UIView {
             .autoconnect()
             .scan(0) { counter, _ in counter + 1 }
             .sink { [self] counter in
+                
+                if counter % 15 == 0 {
+                    Task {
+                        let dispatcherNumber = try await viewModel.countDispatcher()
+                        peopleCountLabel.text = "\(dispatcherNumber ?? 0)"
+                    }
+                    
+                }
                 if counter == 301 {
                     viewModel.timer?.connect().cancel()
                 } else {

--- a/CPR2U/CPR2U/Service/Network/Call/CallEndPoint.swift
+++ b/CPR2U/CPR2U/Service/Network/Call/CallEndPoint.swift
@@ -10,7 +10,8 @@ import Foundation
 enum CallEndPoint {
     case getCallerList
     case callDispatcher(callerLocationInfo: CallerLocationInfo)
-    case situationEnd(callId: Int)    
+    case situationEnd(callId: Int)
+    case countDispatcher(callId: Int)
 }
 
 extension CallEndPoint: EndPoint {
@@ -19,7 +20,7 @@ extension CallEndPoint: EndPoint {
         switch self {
         case .callDispatcher, .situationEnd:
             return .POST
-        case .getCallerList:
+        case .getCallerList, .countDispatcher:
             return .GET
         }
     }
@@ -30,7 +31,7 @@ extension CallEndPoint: EndPoint {
             return nil
         case .callDispatcher(let callerLocationInfo):
             return callerLocationInfo.encode()
-        case .situationEnd:
+        case .situationEnd, .countDispatcher:
             return nil
         }
     }
@@ -44,6 +45,8 @@ extension CallEndPoint: EndPoint {
             return "\(baseURL)/call"
         case .situationEnd(let callId):
             return "\(baseURL)/call/end/\(callId)"
+        case .countDispatcher(let callId):
+            return "\(baseURL)/call/\(callId)"
         }
     }
     
@@ -58,6 +61,8 @@ extension CallEndPoint: EndPoint {
             headers["Content-Type"] = "application/json"
             return NetworkRequest(url: getURL(path: baseURL), httpMethod: method, headers: headers, requestBody: body)
         case .situationEnd:
+            return NetworkRequest(url: getURL(path: baseURL), httpMethod: method, headers: headers)
+        case .countDispatcher:
             return NetworkRequest(url: getURL(path: baseURL), httpMethod: method, headers: headers)
         }
     }

--- a/CPR2U/CPR2U/Service/Network/Call/CallManager.swift
+++ b/CPR2U/CPR2U/Service/Network/Call/CallManager.swift
@@ -11,10 +11,11 @@ protocol CallService {
     func getCallerList() async throws -> (success: Bool, data: CallerListInfo?)
     func callDispatcher(callerLocationInfo: CallerLocationInfo) async throws -> (success: Bool, data: CallResult?)
     func situationEnd(callId: Int) async throws -> (success: Bool, data: CallEndResult?)
+    func countDispatcher(callId: Int) async throws -> (success: Bool, data: DispatcherCountResult?)
 }
 
 struct CallManager: CallService {
-    
+
     private let service: Requestable
     
     init(service: Requestable) {
@@ -42,5 +43,10 @@ struct CallManager: CallService {
         return try await self.service.request(request)
     }
     
-    
+    func countDispatcher(callId: Int) async throws -> (success: Bool, data: DispatcherCountResult?) {
+        let request = CallEndPoint
+            .countDispatcher(callId: callId)
+            .createRequest()
+        return try await self.service.request(request)
+    }
 }


### PR DESCRIPTION
### One line Description
호출 뷰에서 띄워지는 출동 인원 수를 갱신하는 서버 API 추가

### Work Detail(Optional)
**현재 API는 15초마다 호출됩니다.**
|실행 영상|
|:---:|
![](https://user-images.githubusercontent.com/96641477/229094543-8c73cf03-30f8-43a3-bc45-43d884c64620.mp4)|


### Issue
- #57
- Close #57