### PR TITLE
[FIX] #60 회원가입/로그인 시 휴대폰 번호를 입력하지 않은 경우에도 뷰가 넘어가는 에러 수정

### DIFF
--- a/CPR2U/CPR2U/Scene/Login/View/PhoneNumberVertificationViewController.swift
+++ b/CPR2U/CPR2U/Scene/Login/View/PhoneNumberVertificationViewController.swift
@@ -19,7 +19,11 @@ final class PhoneNumberVerificationViewController: UIViewController {
     private let phoneNumberNationLabel = UILabel()
     private let phoneNumberTextField = UITextField()
     
-    private let sendButton = UIButton()
+    private let sendButton: UIButton = {
+        let button = UIButton()
+        button.isEnabled = false
+        return button
+    }()
     
     private var sendButtonBottomConstraints = NSLayoutConstraint()
     


### PR DESCRIPTION
### One line Description
- 회원가입/로그인 시 휴대폰 번호를 입력하지 않은 경우에도 뷰가 넘어가는 에러 수정

### Work Detail(Optional)
`PhoneNumberVerificationViewController`에서 다음 뷰로 넘어가는 역할을 하는 `sendButton`에 버튼 터치 가능 여부에 대한 초기값이 따로 설정되지 않아 발생했던 문제로 판명
**기존 코드**
```swift
// PhoneNumberVerificationViewController.swift line.22
    private let sendButton = UIButton()
```
**수정된 코드**
```swift
// PhoneNumberVerificationViewController.swift line.22-26
    private let sendButton: UIButton = {
        let button = UIButton()
        button.isEnabled = false
        return button
    }()
```

### Issue
- #60
- Close #60