### PR TITLE
[REFACTOR] #69 호출 파트 코드 리팩토링

### DIFF
--- a/CPR2U/CPR2U/Scene/Call/CallViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Call/CallViewModel.swift
@@ -11,6 +11,8 @@ import GoogleMaps
 
 final class CallViewModel: OutputOnlyViewModelType {
     @Published private(set)var callerListInfo: CallerListInfo?
+    @Published private(set)var dispatcherCount: Int?
+    
     private var callManager: CallManager
     
     private var mapManager: MapManager
@@ -88,15 +90,13 @@ final class CallViewModel: OutputOnlyViewModelType {
         }
     }
     
-    func countDispatcher() async throws -> Int? {
-        guard let callId = callId else { return nil }
+    func countDispatcher() {
+        guard let callId = callId else { return }
         
-        let result = Task { () -> Int? in
+        Task {
             let callResult = try await callManager.countDispatcher(callId: callId)
-            return callResult.data?.number_of_angels
+            dispatcherCount = callResult.data?.number_of_angels
         }
-        
-        return try await result.value
     }
     
     private func updateCallId(callId: Int) {

--- a/CPR2U/CPR2U/Scene/Call/DispatchWait/ApproachNoticeView.swift
+++ b/CPR2U/CPR2U/Scene/Call/DispatchWait/ApproachNoticeView.swift
@@ -30,7 +30,7 @@ final class ApproachNoticeView: UIView {
         label.font = UIFont(weight: .bold, size: 20)
         label.textColor = .black
         label.textAlignment = .left
-        label.text = "Approaching"
+        label.text = "approch_des_txt".localized()
         return label
     }()
     
@@ -55,7 +55,7 @@ final class ApproachNoticeView: UIView {
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .mainRed
         button.layer.cornerRadius = 27.5
-        button.setTitle("SITUATION ENDED", for: .normal)
+        button.setTitle("siuation_end_des_txt".localized(), for: .normal)
         return button
     }()
     

--- a/CPR2U/CPR2U/Scene/Call/DispatchWait/ApproachNoticeView.swift
+++ b/CPR2U/CPR2U/Scene/Call/DispatchWait/ApproachNoticeView.swift
@@ -202,7 +202,6 @@ final class ApproachNoticeView: UIView {
                     Task {
                         viewModel.countDispatcher()
                     }
-                    
                 }
                 if counter == 301 {
                     viewModel.timer?.connect().cancel()

--- a/CPR2U/CPR2U/Scene/Call/DispatchWait/ApproachNoticeView.swift
+++ b/CPR2U/CPR2U/Scene/Call/DispatchWait/ApproachNoticeView.swift
@@ -184,6 +184,12 @@ final class ApproachNoticeView: UIView {
                 self.parentViewController().dismiss(animated: true)
             }
         }.store(in: &cancellables)
+        
+        viewModel.$dispatcherCount
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] count in
+                self?.peopleCountLabel.text = "\(count ?? 0)"
+            }.store(in: &cancellables)
     }
     
     private func setTimer() {
@@ -192,11 +198,9 @@ final class ApproachNoticeView: UIView {
             .autoconnect()
             .scan(0) { counter, _ in counter + 1 }
             .sink { [self] counter in
-                
                 if counter % 15 == 0 {
                     Task {
-                        let dispatcherNumber = try await viewModel.countDispatcher()
-                        peopleCountLabel.text = "\(dispatcherNumber ?? 0)"
+                        viewModel.countDispatcher()
                     }
                     
                 }

--- a/CPR2U/CPR2U/Scene/Call/DispatchWait/DispatchWaitViewController.swift
+++ b/CPR2U/CPR2U/Scene/Call/DispatchWait/DispatchWaitViewController.swift
@@ -16,7 +16,7 @@ final class DispatchWaitViewController: UIViewController {
         label.font = UIFont(weight: .bold, size: 64)
         label.textAlignment = .center
         label.textColor = .white
-        label.text = "Call"
+        label.text = "call_tab_t".localized()
         return label
     }()
     

--- a/CPR2U/CPR2U/Scene/Call/DispatchWait/EmergencyDescriptionView.swift
+++ b/CPR2U/CPR2U/Scene/Call/DispatchWait/EmergencyDescriptionView.swift
@@ -14,7 +14,7 @@ final class EmergencyDescriptionView: UIView {
         label.font = UIFont(weight: .bold, size: 20)
         label.textAlignment = .left
         label.textColor = .mainBlack
-        label.text = "Call 911"
+        label.text = "call_ins_txt".localized()
         return label
     }()
     
@@ -24,7 +24,7 @@ final class EmergencyDescriptionView: UIView {
         label.textAlignment = .left
         label.numberOfLines = 4
         label.textColor = .mainBlack
-        label.text = "Calling 911 is the first priority. Ask the people around you to report or perform CPR after reporting. If the report is false, you will be restricted from using the app."
+        label.text = "call_des_txt".localized()
         return label
     }()
     

--- a/CPR2U/CPR2U/Scene/Call/Main/CallMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Call/Main/CallMainViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import CombineCocoa
 import GoogleMaps
 import UIKit
 
@@ -104,9 +105,12 @@ final class CallMainViewController: UIViewController {
     }
     
     private func setUpAction() {
-        let recognizer = UILongPressGestureRecognizer(target: self, action: #selector(didPressCallButton))
-        recognizer.minimumPressDuration = 0.0
-        callButton.addGestureRecognizer(recognizer)
+        let longPress = UILongPressGestureRecognizer()
+        longPress.minimumPressDuration = 0.0
+        callButton.addGestureRecognizer(longPress)
+        longPress.longPressPublisher.sink { [weak self] recognizer in
+            self?.didPressCallButton(recognizer)
+        }.store(in: &cancellables)
         
     }
     

--- a/CPR2U/CPR2U/Scene/Call/Main/CallMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Call/Main/CallMainViewController.swift
@@ -138,24 +138,27 @@ final class CallMainViewController: UIViewController {
     }
     
     private func setUpCallerLocation() {
-            
         Task {
             if !callerLocationMarkers.isEmpty {
                 callerLocationMarkers.forEach({ $0.map = nil })
                 callerLocationMarkers = []
             }
             
-            guard let callerList = try await self.viewModel.receiveCallerList() else { return }
+            viewModel.$callerListInfo
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] callerList in
+                    guard let callerList = callerList else { return }
+                    for caller in callerList.call_list {
+                        let coor = CLLocationCoordinate2D(latitude: caller.latitude, longitude: caller.longitude)
+                        print(coor)
+                        let marker = GMSMarker()
+                        marker.title = String(caller.cpr_call_id)
+                        marker.position = CLLocationCoordinate2DMake(coor.latitude, coor.longitude)
+                        marker.map = self?.mapView
+                        self?.callerLocationMarkers.append(marker)
+                    }
+                }.store(in: &cancellables)
             
-            for caller in callerList.call_list {
-                let coor = CLLocationCoordinate2D(latitude: caller.latitude, longitude: caller.longitude)
-                print(coor)
-                let marker = GMSMarker()
-                marker.title = String(caller.cpr_call_id)
-                marker.position = CLLocationCoordinate2DMake(coor.latitude, coor.longitude)
-                marker.map = mapView
-                callerLocationMarkers.append(marker)
-            }
         }
     }
     
@@ -178,17 +181,9 @@ final class CallMainViewController: UIViewController {
         output.currentLocationAddress?.sink { address in
             self.currentLocationNoticeView.setUpLocationLabelText(as: address)
         }.store(in: &cancellables)
-        
-        output.callerList?.sink { list in
-            print(list)
-            if list.angel_status == "ACQUIRED" && !list.is_patient {
-                print(list.call_list)
-            }
-            
-        }.store(in: &cancellables)
     }
     
-    @objc func didPressCallButton(_ sender: UILongPressGestureRecognizer) {
+    private func didPressCallButton(_ sender: UILongPressGestureRecognizer) {
         let state = sender.state
         if state == .began {
             callButton.progressAnimation()
@@ -204,7 +199,7 @@ extension CallMainViewController: GMSMapViewDelegate {
     func mapView(_ mapView: GMSMapView, didTap marker: GMSMarker) -> Bool
     {
         guard let callId = Int(marker.title ?? "0") else { return false }
-        guard let target = viewModel.callerList?.value.call_list.filter{$0.cpr_call_id == callId}.first else { return false }
+        guard let target = viewModel.callerListInfo?.call_list.filter({$0.cpr_call_id == callId}).first else { return false }
         
         let callerInfo = CallerCompactInfo(callerId: target.cpr_call_id, latitude: target.latitude, longitude: target.longitude, callerAddress: target.full_address)
         let navigationController = UINavigationController(rootViewController: DispatchViewController(userLocation: viewModel.getLocation(), callerInfo: callerInfo))

--- a/CPR2U/CPR2U/en.lproj/Localizable.strings
+++ b/CPR2U/CPR2U/en.lproj/Localizable.strings
@@ -98,3 +98,9 @@ phdr: placeholder
 "pe_des_txt_2" = "Put the plastic bottle inside the clothes\nyou don't wear and wrap it up.";
 "pe_des_txt_3" = "Draw an angry man on your clothes or pillow\nusing tape or pen.";
 "pe_des_txt_4" = "Please press the location marked in red!";
+
+// Dispatch
+"approch_des_txt" = "Approaching";
+"siuation_end_des_txt" = "SITUATION ENDED";
+"call_ins_txt" = "Call 911";
+"call_des_txt" = "Calling 911 is the first priority. Ask the people around you to report or perform CPR after reporting. If the report is false, you will be restricted from using the app.";


### PR DESCRIPTION
### One line Description
- 호출 파트와 관련된 코드 전반에 걸친 리팩토링

### Work Detail(Optional)
**1. 호출 탭에서 사용된 `CallViewModel`의 뷰 정보 전달 형태 수정**
- 기존 코드의 경우 `Async Await`를 통해 서버로부터 데이터를 전송받은 후 다이렉트하게 Output으로 전해주며 뷰와 교류
- 변경된 코드의 경우 서버로부터 전송받은 데이터를 `CallViewModel`에서 전달받은 후 이를 `@Published` 프로퍼티를 통해 전달
```swift
// CallViewModel.swift
@Published private(set)var callerListInfo: CallerListInfo?

    init() {
        receiveCallerList()
    }

    func receiveCallerList() {
        Task {
            let callResult = try await callManager.getCallerList()
            
            guard let list = callResult.data else { return }
            callerListInfo = list
        }
    }
```
---
**2. 출동 Angel Count 로직 변경**
- 기존 코드: 1과 동일하게 여러 번에 걸친 Async Await를 통해 관리
- 변경된 코드 `@Published`를 통해 그대로 View에서는 서버 API 호출 로직을 단순히 호출하고, 갱신되는 값(`@Published`)을 받아 UI를 갱신할 수 있도록 변경
```swift
// CallViewModel.swift
@Published private(set)var dispatcherCount: Int?
    func countDispatcher() {
        guard let callId = callId else { return }
        
        Task {
            let callResult = try await callManager.countDispatcher(callId: callId)
            dispatcherCount = callResult.data?.number_of_angels
        }
    }
```
```swift
// ApproachNoticeView.swift
    private func bind(viewModel: CallViewModel) {    
        viewModel.$dispatcherCount
            .receive(on: DispatchQueue.main)
            .sink { [weak self] count in
                self?.peopleCountLabel.text = "\(count ?? 0)"
            }.store(in: &cancellables)
    }

    private func setTimer() {
        viewModel.timer = Timer.publish(every: 1,tolerance: 0.9, on: .main, in: .default)
        viewModel.timer?
            .autoconnect()
            .scan(0) { counter, _ in counter + 1 }
            .sink { [self] counter in
                if counter % 15 == 0 {
                    Task {
                        viewModel.countDispatcher()
                    }
                }
                if counter == 301 {
                    viewModel.timer?.connect().cancel()
                } else {
                    timeLabel.text = counter.numberAsTime()
                }
            }.store(in: &cancellables)
    }
```
---
**3. 교육 파트 전반에서 사용된 Strings -> Localized String으로 이전**
---

### 특이사항
- Timer 관련 로직도 ViewModel 내부에서 처리하는 형태로 변경한다면 코드가 더 간결해지지 않을까?
### Issue
- #69 
- Close #69 