### PR TITLE
[FIX] SMS 인증코드 전송 뷰 Code Resend Action 추가 (#73)

### DIFF
--- a/CPR2U/CPR2U/Scene/Login/AuthViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Login/AuthViewModel.swift
@@ -24,7 +24,7 @@ final class AuthViewModel: AuthViewModelType {
     var phoneNumber: String {
         get {
             guard let str = _phoneNumber else { return "" }
-            return "+82 \(str)"
+            return str
         }
         set(value) {
             _phoneNumber = value

--- a/CPR2U/CPR2U/Scene/Login/View/SMSCodeVertificationViewController.swift
+++ b/CPR2U/CPR2U/Scene/Login/View/SMSCodeVertificationViewController.swift
@@ -34,7 +34,7 @@ final class SMSCodeVerificationViewController: UIViewController {
         label.font = UIFont(weight: .bold, size: 16)
         label.textAlignment = .left
         label.textColor = .mainBlack
-        label.text = self.viewModel.phoneNumber
+        label.text = "+82 \(self.viewModel.phoneNumber)"
         return label
     }()
     
@@ -49,6 +49,7 @@ final class SMSCodeVerificationViewController: UIViewController {
         label.textAlignment = .right
         label.textColor = .mainRed
         label.text = "code_resend_ins_txt".localized()
+        label.isUserInteractionEnabled = true
         return label
     }()
     
@@ -91,6 +92,7 @@ final class SMSCodeVerificationViewController: UIViewController {
         
         setUpConstraints()
         setUpStyle()
+        setUpAction()
         setUpLayerName()
         setUpKeyboard()
         bind(viewModel: viewModel)
@@ -247,6 +249,18 @@ final class SMSCodeVerificationViewController: UIViewController {
                 } else {
                     print("인증코드 오류")
                 }
+            }
+        }.store(in: &cancellables)
+    }
+    
+    private func setUpAction() {
+        let tapGesture = UITapGestureRecognizer()
+        
+        codeResendLabel.addGestureRecognizer(tapGesture)
+        tapGesture.tapPublisher.sink { [weak self] _ in
+            Task {
+                guard let phoneNumber = self?.viewModel.phoneNumber else { return }
+                _ = try await self?.viewModel.phoneNumberVerify(phoneNumber: phoneNumber)
             }
         }.store(in: &cancellables)
     }


### PR DESCRIPTION
### One line Description
- 회원가입/로그인 절차에서 Code Resend Label에 Action 부여

### Work Detail(Optional)
**CombineCocoa의 tapPublisher를 사용하여 Action 추가**
```swift
//SMSCodeVerificationViewController.swift

    private let codeResendLabel: UILabel = {
        let label = UILabel()
        label.isUserInteractionEnabled = true // label의 userInteraction 옵션 기본값은 false이므로 주의
        return label
    }()

    private func setUpAction() {
        let tapGesture = UITapGestureRecognizer()
        
        codeResendLabel.addGestureRecognizer(tapGesture)
        tapGesture.tapPublisher.sink { [weak self] _ in
            Task {
                guard let phoneNumber = self?.viewModel.phoneNumber else { return }
                _ = try await self?.viewModel.phoneNumberVerify(phoneNumber: phoneNumber)
            }
        }.store(in: &cancellables)
    }
```

### 비고
- Auth View Model의 추가적인 Refactoring 작업이 수행 시 tapGesture 코드부를 개선할 예정

### Issue
- #73
- Close #73