### PR TITLE
[REFACTOR] #72 출동 파트 코드 리팩토링

### DIFF
--- a/CPR2U/CPR2U/Scene/Dispatch/DispatchViewController.swift
+++ b/CPR2U/CPR2U/Scene/Dispatch/DispatchViewController.swift
@@ -245,11 +245,14 @@ final class DispatchViewController: UIViewController {
     }
     
     private func setUpAction() {
-        let gesture = UITapGestureRecognizer(target: self, action: #selector(didTapReportButton))
-        reportLabel.addGestureRecognizer(gesture)
+        let tapGesture = UITapGestureRecognizer()
+        reportLabel.addGestureRecognizer(tapGesture)
+        tapGesture.tapPublisher.sink { [weak self] _ in
+            self?.didTapReportButton()
+        }.store(in: &cancellables)
     }
     
-    @objc func didTapReportButton() {
+    private func didTapReportButton() {
         guard let dispatchId = dispatchId else { return }
         let vc = ReportViewController(dispatchId: dispatchId, manager: manager)
         vc.modalPresentationStyle = .fullScreen

--- a/CPR2U/CPR2U/Scene/Dispatch/DispatchViewController.swift
+++ b/CPR2U/CPR2U/Scene/Dispatch/DispatchViewController.swift
@@ -65,7 +65,7 @@ final class DispatchViewController: UIViewController {
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .mainRed
         button.layer.cornerRadius = 27.5
-        button.setTitle("DISPATCH", for: .normal)
+        button.setTitle("dispatch_tab_t".localized(), for: .normal)
         return button
     }()
     
@@ -74,7 +74,7 @@ final class DispatchViewController: UIViewController {
         label.font = UIFont(weight: .regular, size: 14)
         label.textColor = .mainBlack
         label.textAlignment = .right
-        label.text = "Wrong Report? Report"
+        label.text = "report_title_txt".localized()
         label.isHidden = true
         label.isUserInteractionEnabled = true
         return label
@@ -217,7 +217,7 @@ final class DispatchViewController: UIViewController {
                     if result.success {
                         dispatchId = result.data?.dispatch_id
                         isModalInPresentation = true
-                        dispatchButton.setTitle("ARRIVED", for: .normal)
+                        dispatchButton.setTitle("arrive_des_txt".localized(), for: .normal)
                         stackView.isHidden = true
                         reportLabel.isHidden = false
                         timerAppear()
@@ -230,7 +230,6 @@ final class DispatchViewController: UIViewController {
     }
     
     private func setupSheet() {
-        
         if let sheet = sheetPresentationController {
             sheet.detents = [.custom { _ in return 300 }]
             sheet.selectedDetentIdentifier = .medium
@@ -278,9 +277,6 @@ extension DispatchViewController {
             }
         }
         
-        print("RAW: \(rawDistance)")
-        print("FLOOR: \(floorDistance)")
-        print(distanceStr)
         durationView.setUpDescription(text:  "\(duration)m")
         distanceView.setUpDescription(text: distanceStr)
     }

--- a/CPR2U/CPR2U/Scene/Dispatch/ReportViewController.swift
+++ b/CPR2U/CPR2U/Scene/Dispatch/ReportViewController.swift
@@ -18,7 +18,7 @@ final class ReportViewController: UIViewController {
         label.adjustsFontSizeToFitWidth = true
         label.minimumScaleFactor = 0.5
         label.textColor = .mainBlack
-        label.text = "What are you trying to report?"
+        label.text = "report_ins_txt".localized()
         return label
     }()
     
@@ -27,11 +27,11 @@ final class ReportViewController: UIViewController {
         label.font = UIFont(weight: .regular, size: 14)
         label.textAlignment = .left
         label.textColor = .mainBlack
-        label.text = "Your report will be treated anonymously."
+        label.text = "report_des_txt".localized()
         return label
     }()
     
-    private let placeHolder = "Content*"
+    private let placeHolder = "report_phdr".localized()
     private let reportTextView: UITextView = {
         let view = UITextView()
         view.layer.cornerRadius = 6
@@ -51,7 +51,7 @@ final class ReportViewController: UIViewController {
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .mainRed
         button.layer.cornerRadius = 27.5
-        button.setTitle("SUBMIT", for: .normal)
+        button.setTitle("submit".localized(), for: .normal)
         return button
     }()
     
@@ -173,7 +173,7 @@ extension ReportViewController: UITextViewDelegate {
             textView.textColor = .black
         }
     }
-    
+
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             textView.text = placeHolder

--- a/CPR2U/CPR2U/Scene/Login/View/NicknameVertificationViewController.swift
+++ b/CPR2U/CPR2U/Scene/Login/View/NicknameVertificationViewController.swift
@@ -23,7 +23,7 @@ enum NicknameStatus {
         case .specialCharacters:
             str = "nickname_special_character".localized()
         case .unavailable:
-            let localizedStr = String(format: "%s_nickname_unavailable".localized(), name)
+            let localizedStr = String(format: "%@_nickname_unavailable".localized(), name)
             str = localizedStr
         case .available:
             str = ""

--- a/CPR2U/CPR2U/en.lproj/Localizable.strings
+++ b/CPR2U/CPR2U/en.lproj/Localizable.strings
@@ -28,6 +28,7 @@ phdr: placeholder
 "confirm" = "CONFIRM";
 "continue" = "CONTINUE";
 "cancel" = "CANCEL";
+"submit" = "SUBMIT";
 "quit" = "QUIT";
 "completed" = "Completed";
 "completed_not" = "Not Completed";
@@ -99,8 +100,16 @@ phdr: placeholder
 "pe_des_txt_3" = "Draw an angry man on your clothes or pillow\nusing tape or pen.";
 "pe_des_txt_4" = "Please press the location marked in red!";
 
-// Dispatch
+// Call
 "approch_des_txt" = "Approaching";
 "siuation_end_des_txt" = "SITUATION ENDED";
 "call_ins_txt" = "Call 911";
 "call_des_txt" = "Calling 911 is the first priority. Ask the people around you to report or perform CPR after reporting. If the report is false, you will be restricted from using the app.";
+
+// Dispatch
+"dispatch_tab_t" = "DISPATCH";
+"arrive_des_txt" = "ARRIVED";
+"report_title_txt" = "Wrong Report? Report";
+"report_ins_txt" = "What are you trying to report?";
+"report_des_txt" = "Your report will be treated anonymously.";
+"report_phdr" = "Content*";


### PR DESCRIPTION
### One line Description
- 출동 파트와 관련된 코드 전반에 걸친 리팩토링

### Work Detail(Optional)
**1. UILabel의 TapGesture -> CombineCocoa 기반으로 변경**
- 기존 코드의 경우 delegate pattern을 사용하여 구현
- 변경된 코드의 경우 CombineCocoa의 TapPublisher를 통해 구현
```swift
// DispatchViewController.swift
    private func setUpAction() {
        let tapGesture = UITapGestureRecognizer()
        reportLabel.addGestureRecognizer(tapGesture)
        tapGesture.tapPublisher.sink { [weak self] _ in
            self?.didTapReportButton()
        }.store(in: &cancellables)
    }
    
    private func didTapReportButton() {
        guard let dispatchId = dispatchId else { return }
        let vc = ReportViewController(dispatchId: dispatchId, manager: manager)
        vc.modalPresentationStyle = .fullScreen
        present(vc, animated: true)
    }
```

---

**2. 출동 파트 전반에서 사용된 Strings -> Localized String으로 이전**

---
### 비고
- UITextView의 delegate -> combine으로 추후 전환할 예정입니다.
- 출동 파트의 ViewModel 작성은 우선순위가 낮다고 판단하여 유보합니다.
### Issue
- #72
- Close #72