### PR TITLE
[FIX] #92 UT 기반 발견 오류 및 UI 수정

### DIFF
--- a/CPR2U/CPR2U/Scene/Dispatch/DispatchTimerView.swift
+++ b/CPR2U/CPR2U/Scene/Dispatch/DispatchTimerView.swift
@@ -137,7 +137,7 @@ class DispatchTimerView: UIView {
                     let userLocation = manager.setLocation()
                     guard let callerInfo = callerInfo else { return }
                     let distance = calculateDistanceFromCurrentLocation(callerInfo: callerInfo, userLocation: userLocation)
-                    if distance < 70 { // ORIGIN
+                    if distance < 20 {
                         guard let dispatchId = dispatchId else { return }
                         Task {
                             guard let viewModel = viewModel else { return }

--- a/CPR2U/CPR2U/Scene/Education/EducationViewModel.swift
+++ b/CPR2U/CPR2U/Scene/Education/EducationViewModel.swift
@@ -193,7 +193,7 @@ enum AngelStatus: Int {
 }
 
 enum TimerType: Int {
-    case lecture = 120
+    case lecture = 3000
     case posture =  126
     case other = 0
 }

--- a/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Main/EducationMainViewController.swift
@@ -123,7 +123,7 @@ final class EducationMainViewController: UIViewController {
             
             output.certificateStatus?.sink { status in
                 self.certificateStatusView.setUpStatus(as: status.status, leftDay: status.leftDay)
-                if status.status == .acquired{
+                if status.status == .acquired {
                     if UserDefaultsManager.isCertificateNotice == false {
                         self.noticeView.noticeAppear()
                         UserDefaultsManager.isCertificateNotice = true

--- a/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/EducationQuizViewController.swift
@@ -116,7 +116,7 @@ final class EducationQuizViewController: UIViewController {
             oxChoiceView.topAnchor.constraint(equalTo: questionView.bottomAnchor, constant: 78),
             oxChoiceView.heightAnchor.constraint(equalToConstant: 80),
             multiChoiceView.topAnchor.constraint(equalTo: questionView.bottomAnchor, constant: 36),
-            multiChoiceView.heightAnchor.constraint(equalToConstant: 280)
+            multiChoiceView.heightAnchor.constraint(equalToConstant: 286)
         ])
         
         NSLayoutConstraint.activate([

--- a/CPR2U/CPR2U/Scene/Education/Quiz/MultiQuizChoiceView.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/MultiQuizChoiceView.swift
@@ -39,29 +39,19 @@ final class MultiQuizChoiceView: QuizChoiceView {
         self.addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
-        
-        choices.forEach({
-            stackView.addSubview($0)
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            
-            $0.widthAnchor.constraint(equalToConstant: 334).isActive = true
-            $0.heightAnchor.constraint(equalToConstant: 52).isActive = true
-            $0.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
-        })
-        
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: self.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            stackView.widthAnchor.constraint(equalToConstant: 260)
+            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 12),
+            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12)
         ])
         
-        NSLayoutConstraint.activate([
-            choices[0].topAnchor.constraint(equalTo: stackView.topAnchor),
-            choices[1].topAnchor.constraint(equalTo: choices[0].bottomAnchor, constant: 26),
-            choices[2].topAnchor.constraint(equalTo: choices[1].bottomAnchor, constant: 26),
-            choices[3].topAnchor.constraint(equalTo: choices[2].bottomAnchor, constant: 26)
-        ])
+        choices.forEach({
+            stackView.addArrangedSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            $0.heightAnchor.constraint(equalToConstant: 52).isActive = true
+            $0.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+        })
         
         answerCenterPosition = choices[1].center
     }

--- a/CPR2U/CPR2U/Scene/Education/Quiz/MultiQuizChoiceView.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/MultiQuizChoiceView.swift
@@ -30,6 +30,8 @@ final class MultiQuizChoiceView: QuizChoiceView {
     }
     
     override func setUpConstraints() {
+        let make = Constraints.shared
+        
         let stackView   = UIStackView()
         stackView.axis  = NSLayoutConstraint.Axis.vertical
         stackView.distribution  = UIStackView.Distribution.equalSpacing
@@ -42,18 +44,15 @@ final class MultiQuizChoiceView: QuizChoiceView {
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: self.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 12),
-            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12)
+            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: make.space12),
+            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -make.space12)
         ])
         
-        var configuration = UIButton.Configuration.plain()
-        configuration.titlePadding = 8
         choices.forEach({
             stackView.addArrangedSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.heightAnchor.constraint(equalToConstant: 52).isActive = true
             $0.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
-            $0.configuration = configuration
         })
         answerCenterPosition = choices[1].center
     }
@@ -65,9 +64,7 @@ final class MultiQuizChoiceView: QuizChoiceView {
             $0.layer.borderColor = UIColor.mainRed.cgColor
             $0.layer.cornerRadius = 20
             $0.titleLabel?.font = UIFont(weight: .regular, size: 26)
-            $0.titleLabel?.minimumScaleFactor = 0.15
             $0.titleLabel?.numberOfLines = 1
-            $0.titleLabel?.adjustsFontSizeToFitWidth = true
             $0.titleLabel?.lineBreakMode = NSLineBreakMode.byClipping
             $0.setTitleColor(.mainBlack, for: .normal)
         })

--- a/CPR2U/CPR2U/Scene/Education/Quiz/MultiQuizChoiceView.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/MultiQuizChoiceView.swift
@@ -46,13 +46,15 @@ final class MultiQuizChoiceView: QuizChoiceView {
             stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12)
         ])
         
+        var configuration = UIButton.Configuration.plain()
+        configuration.titlePadding = 8
         choices.forEach({
             stackView.addArrangedSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.heightAnchor.constraint(equalToConstant: 52).isActive = true
             $0.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
+            $0.configuration = configuration
         })
-        
         answerCenterPosition = choices[1].center
     }
     

--- a/CPR2U/CPR2U/Scene/Education/Quiz/QuizChoiceView.swift
+++ b/CPR2U/CPR2U/Scene/Education/Quiz/QuizChoiceView.swift
@@ -70,7 +70,14 @@ public class QuizChoiceView: UIView {
             choices[1].setTitle("X", for: .normal)
         } else {
             for (index, choice) in choices.enumerated() {
-                choice.setTitle(answers?[index], for: .normal)
+                guard let answer = answers?[index] else { return }
+                choice.setTitle(answer, for: .normal)
+                
+                if answer.count > 24 {
+                    choice.titleLabel?.font = UIFont(weight: .regular, size: 20)
+                } else {
+                    choice.titleLabel?.font = UIFont(weight: .regular, size: 26)
+                }
             }
         }
     }

--- a/CPR2U/CPR2U/Scene/Mypage/MypageViewController.swift
+++ b/CPR2U/CPR2U/Scene/Mypage/MypageViewController.swift
@@ -163,6 +163,7 @@ extension MypageViewController: UITableViewDelegate, UITableViewDataSource {
                         await window.setRootViewController(AutoLoginViewController(), animated: true)
                         UserDefaultsManager.accessToken = ""
                         UserDefaultsManager.refreshToken = ""
+                        UserDefaultsManager.isCertificateNotice = false
                         self?.dismiss(animated: true)
                     }
                 }


### PR DESCRIPTION
### One line Description
- User Testing 과정에서 발견한 오류 및 UI 수정

### Work Detail(Optional)
**Error.1 로그아웃 후 다른 계정 접속 시 수료증을 최초 발급한 경우에도 수료증 갱신이 되지 않음**
- 로그아웃 API 호출 시 response가 200으로 돌아온 경우에 대해 수료증 취득과 관련된 UserDefaults를 false로 전환
```swift
// MypageViewController.swift line.159-169
        Task { [weak self] in
                    let isSuccess = try await self?.authViewModel.logOut()
                    if isSuccess == true {
                        guard let window = self?.view.window else { return }
                        await window.setRootViewController(AutoLoginViewController(), animated: true)
                        UserDefaultsManager.accessToken = ""
                        UserDefaultsManager.refreshToken = ""
                        UserDefaultsManager.isCertificateNotice = false
                        self?.dismiss(animated: true)
                    }
                }
```

**UI.1 퀴즈 UI에서 긴 Text Margin 확보하기**
|기존 화면|수정된 화면|
|:---:|:---:|
|![Screenshot1](https://github.com/CPR2U/CPR2U-iOS/assets/96641477/f014d2a9-4efe-4c84-8ef5-d2f012e48474)|![Screenshot2](https://github.com/CPR2U/CPR2U-iOS/assets/96641477/2bc18e9a-8d95-4f67-9f18-3f2297b7bb3f)|

**Function.1 사용자의 위치로부터 70m 떨어진 지점에 도착하는 경우에 Confirm 처리는 거리가 너무 멂**
- 20m 내로 수정
```swift
// DispatchTimerView.swfit line.137-140
let userLocation = manager.setLocation()
                    guard let callerInfo = callerInfo else { return }
                    let distance = calculateDistanceFromCurrentLocation(callerInfo: callerInfo, userLocation: userLocation)
                    if distance < 20 {
```
### Issue
- #92
- Close #92